### PR TITLE
feat(sidebar): tear down agent processes on archive

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -66,6 +66,7 @@ impl CloseReason {
                     "Agent killed: runtime capability changed".to_owned()
                 }
                 Some(AgentKillReason::SessionRevoked) => "Agent killed: session revoked".to_owned(),
+                Some(AgentKillReason::Archived) => "Agent killed: archived".to_owned(),
                 None => "Agent killed".to_owned(),
             },
             CloseReason::ProcessExited {

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -6,12 +6,13 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use aionui_ai_agent::{AgentRouterState, AgentService, RemoteAgentRouterState, RemoteAgentService};
+use aionui_ai_agent::{AgentRouterState, AgentService, IWorkerTaskManager, RemoteAgentRouterState, RemoteAgentService};
 use aionui_assistant::{
     AssistantAgentCatalogPort, AssistantError, AssistantRouterState, AssistantService, BuiltinAssistantRegistry,
 };
 use aionui_auth::extract_token_from_ws_headers;
 use aionui_channel::ChannelRouterState;
+use aionui_common::AgentKillReason;
 use aionui_conversation::{ConversationRouterState, ConversationService};
 use aionui_cron::{CronEventEmitter, CronRouterState, service::CronServiceDeps};
 use aionui_db::{
@@ -40,7 +41,7 @@ use aionui_session_message::drainer::Drainer;
 use aionui_session_message::state::SessionMessageRouterState;
 use aionui_session_message::targets::MentionableTargets;
 use aionui_shell::ShellRouterState;
-use aionui_sidebar::{SidebarRouterState, SidebarService};
+use aionui_sidebar::{ArchiveTeardownPorts, SidebarRouterState, SidebarService};
 use aionui_system::{
     ClientPrefService, ConnectionTestRouterState, ConnectionTestService, FeedbackDiagnosticsService, ModelFetchService,
     ProtocolDetectionService, ProviderService, RuntimePrepareService, SettingsService, SystemRouterState,
@@ -346,6 +347,17 @@ pub async fn build_module_states(
             team: states.team.service.clone(),
             project: services.project_service.clone(),
         }));
+    // Same late-injection as above: the archive paths release the agent runtime
+    // via the worker task manager (per-conversation kill) and the team service
+    // (team runtime + member kills), neither of which exists when the sidebar
+    // state is built. `set_archive_teardown_ports` is set-once.
+    states
+        .sidebar
+        .service
+        .set_archive_teardown_ports(Arc::new(ArchiveTeardownAdapter {
+            task_manager: services.worker_task_manager.clone(),
+            team: states.team.service.clone(),
+        }));
     states
         .conversation
         .service
@@ -595,6 +607,36 @@ impl aionui_sidebar::RemoveProjectPorts for RemoveProjectAdapter {
     async fn delete_project_record(&self, user_id: &str, project_id: &str) -> Result<(), String> {
         self.project
             .delete_project(user_id, project_id)
+            .await
+            .map_err(|err| err.to_string())
+    }
+}
+
+/// Adapts the process-teardown paths to the sidebar's
+/// [`aionui_sidebar::ArchiveTeardownPorts`] trait so the archive flip can
+/// release the agent runtime the same way delete does — kill the conversation's
+/// agent process, tear down the team runtime — without deleting any data and
+/// without the sidebar crate depending on the ai-agent / team crates.
+struct ArchiveTeardownAdapter {
+    task_manager: Arc<dyn IWorkerTaskManager>,
+    team: Arc<TeamSessionService>,
+}
+
+#[async_trait::async_trait]
+impl ArchiveTeardownPorts for ArchiveTeardownAdapter {
+    async fn stop_conversation(&self, _user_id: &str, conversation_id: &str) -> Result<(), String> {
+        // Ownership was already verified by the owner-scoped archive flip; this
+        // is a pure process kill (no DB write). `kill_and_wait` is a no-op for a
+        // conversation with no live runtime, so an already-idle agent is fine.
+        self.task_manager
+            .kill_and_wait(conversation_id, Some(AgentKillReason::Archived))
+            .await;
+        Ok(())
+    }
+
+    async fn stop_team(&self, user_id: &str, team_id: &str) -> Result<(), String> {
+        self.team
+            .stop_team_processes(user_id, team_id)
             .await
             .map_err(|err| err.to_string())
     }

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -283,6 +283,12 @@ pub enum AgentKillReason {
     /// The owning user's Core session was revoked, so foreground runtime state
     /// and agent processes for that user must be torn down.
     SessionRevoked,
+    /// The owning conversation (or its team) was archived. Like
+    /// `ConversationDeleted` the agent process is torn down so it stops
+    /// streaming for a unit the user moved out of the active workspace, but the
+    /// conversation row and history are preserved — unarchiving cold-starts a
+    /// fresh agent.
+    Archived,
 }
 
 /// File change operation type.

--- a/crates/aionui-sidebar/src/lib.rs
+++ b/crates/aionui-sidebar/src/lib.rs
@@ -14,7 +14,7 @@ mod types;
 pub mod routes;
 
 pub use cascade::UserOrderDeleteHook;
-pub use ports::RemoveProjectPorts;
+pub use ports::{ArchiveTeardownPorts, RemoveProjectPorts};
 pub use routes::{SidebarRouterState, sidebar_routes};
 pub use service::SidebarService;
 pub use types::SidebarError;

--- a/crates/aionui-sidebar/src/ports.rs
+++ b/crates/aionui-sidebar/src/ports.rs
@@ -31,3 +31,27 @@ pub trait RemoveProjectPorts: Send + Sync {
     /// Delete the project record and its explorer entries (owner-scoped).
     async fn delete_project_record(&self, user_id: &str, project_id: &str) -> Result<(), String>;
 }
+
+/// Process-teardown ports for archiving (parallel to `RemoveProjectPorts`, but
+/// stop-only — no data is deleted).
+///
+/// Archiving used to flip `archived_at` and stop there, leaving the agent
+/// process streaming for a unit the user just moved out of the active
+/// workspace. These primitives let the archive path release the runtime the
+/// same way delete does — kill the agent process / tear down the team runtime —
+/// while the conversation and history rows are preserved (unarchiving
+/// cold-starts a fresh agent). Same cross-crate seam rationale as
+/// `RemoveProjectPorts`: the sidebar crate must not depend on the conversation /
+/// team services directly, so `aionui-app` injects an adapter.
+///
+/// Errors are opaque strings: teardown is best-effort (the archive flip already
+/// succeeded), so the sidebar only needs "this failed" for a warn log.
+#[async_trait]
+pub trait ArchiveTeardownPorts: Send + Sync {
+    /// Stop one conversation's agent process (kill + wait), keeping its rows.
+    async fn stop_conversation(&self, user_id: &str, conversation_id: &str) -> Result<(), String>;
+
+    /// Stop a whole team's runtime and every member agent process, keeping all
+    /// rows.
+    async fn stop_team(&self, user_id: &str, team_id: &str) -> Result<(), String>;
+}

--- a/crates/aionui-sidebar/src/service.rs
+++ b/crates/aionui-sidebar/src/service.rs
@@ -31,7 +31,7 @@ use aionui_db::{
 };
 use aionui_project::canonical;
 
-use crate::ports::RemoveProjectPorts;
+use crate::ports::{ArchiveTeardownPorts, RemoveProjectPorts};
 use crate::types::{
     Cursor, DEFAULT_ITEMS_LIMIT, DEFAULT_LIMIT, ScopeToken, SidebarError, canonical_to_dir_key, validate_limit,
 };
@@ -54,6 +54,11 @@ pub struct SidebarService {
     /// team service they wrap is built after this service — see
     /// `build_module_states`). Empty in the read/pin paths, which never touch it.
     remove_project_ports: Arc<OnceLock<Arc<dyn RemoveProjectPorts>>>,
+    /// Process-teardown ports the archive paths drive (stop-only, no delete),
+    /// injected once after startup like `remove_project_ports`. Empty in the
+    /// read/pin paths. Absent → archive still flips `archived_at`; only the
+    /// best-effort process teardown is skipped.
+    archive_teardown_ports: Arc<OnceLock<Arc<dyn ArchiveTeardownPorts>>>,
 }
 
 impl SidebarService {
@@ -63,6 +68,7 @@ impl SidebarService {
             user_order,
             work_dir,
             remove_project_ports: Arc::new(OnceLock::new()),
+            archive_teardown_ports: Arc::new(OnceLock::new()),
         }
     }
 
@@ -72,6 +78,13 @@ impl SidebarService {
     /// clone makes it visible everywhere.
     pub fn set_remove_project_ports(&self, ports: Arc<dyn RemoveProjectPorts>) {
         let _ = self.remove_project_ports.set(ports);
+    }
+
+    /// Install the process-teardown ports the archive paths drive. Called once,
+    /// after the conversation / team services exist (set-once, `Arc`-shared like
+    /// [`set_remove_project_ports`](Self::set_remove_project_ports)).
+    pub fn set_archive_teardown_ports(&self, ports: Arc<dyn ArchiveTeardownPorts>) {
+        let _ = self.archive_teardown_ports.set(ports);
     }
 
     // -- Write side (pin / unpin) --------------------------------------------
@@ -106,6 +119,9 @@ impl SidebarService {
         {
             return Err(SidebarError::ScopeGone);
         }
+        // The archive flip is now committed; release the agent process the same
+        // way delete does (best-effort — the row already moved slice).
+        self.stop_conversation_best_effort(user_id, id).await;
         self.unpin_item(user_id, OrderItemType::Conversation, id).await
     }
 
@@ -126,6 +142,9 @@ impl SidebarService {
         if !self.sidebar.set_team_archived(user_id, id, Some(now_ms())).await? {
             return Err(SidebarError::ScopeGone);
         }
+        // Flip committed (store already cascaded members); tear down the team
+        // runtime and member agents the same way delete does (best-effort).
+        self.stop_team_best_effort(user_id, id).await;
         self.unpin_item(user_id, OrderItemType::Team, id).await
     }
 
@@ -144,6 +163,30 @@ impl SidebarService {
         let item = OrderItemRef::new(item_type, id.to_owned());
         self.user_order.unpin(user_id, OrderScene::Pinned, &item).await?;
         Ok(())
+    }
+
+    /// Stop an archived conversation's agent process (best-effort). A missing
+    /// port (not yet wired) or a teardown error only warns: the archive flip has
+    /// already committed, so a lingering process is a leak to log, not a reason
+    /// to fail the archive.
+    async fn stop_conversation_best_effort(&self, user_id: &str, id: &str) {
+        let Some(ports) = self.archive_teardown_ports.get() else {
+            return;
+        };
+        if let Err(err) = ports.stop_conversation(user_id, id).await {
+            tracing::warn!(conversation_id = %id, error = %err, "archive: conversation teardown failed");
+        }
+    }
+
+    /// Stop an archived team's runtime and member agents (best-effort; same
+    /// rationale as [`stop_conversation_best_effort`](Self::stop_conversation_best_effort)).
+    async fn stop_team_best_effort(&self, user_id: &str, id: &str) {
+        let Some(ports) = self.archive_teardown_ports.get() else {
+            return;
+        };
+        if let Err(err) = ports.stop_team(user_id, id).await {
+            tracing::warn!(team_id = %id, error = %err, "archive: team teardown failed");
+        }
     }
 
     /// Reposition a pinned item by drag-drop (`POST /api/order/{scene}/move`).

--- a/crates/aionui-sidebar/src/service_test.rs
+++ b/crates/aionui-sidebar/src/service_test.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use tempfile::TempDir;
 
 use super::{SidebarError, SidebarService};
-use crate::ports::RemoveProjectPorts;
+use crate::ports::{ArchiveTeardownPorts, RemoveProjectPorts};
 
 const USER: &str = "user-1";
 const OTHER: &str = "user-2";
@@ -883,6 +883,45 @@ impl RemoveProjectPorts for FakePorts {
     }
 }
 
+/// An `ArchiveTeardownPorts` that only records which ids it was asked to stop.
+/// Teardown is a pure process op in production (no DB write), so the fake just
+/// captures the calls; tests assert the archive path drives it. A `fail` id
+/// forces one call to error, exercising the best-effort warn-and-continue path.
+struct FakeTeardownPorts {
+    fail: HashSet<String>,
+    stopped_convs: Mutex<Vec<String>>,
+    stopped_teams: Mutex<Vec<String>>,
+}
+
+impl FakeTeardownPorts {
+    fn new(fail: &[&str]) -> Arc<Self> {
+        Arc::new(Self {
+            fail: fail.iter().map(|s| s.to_string()).collect(),
+            stopped_convs: Mutex::new(Vec::new()),
+            stopped_teams: Mutex::new(Vec::new()),
+        })
+    }
+}
+
+#[async_trait]
+impl ArchiveTeardownPorts for FakeTeardownPorts {
+    async fn stop_conversation(&self, _user_id: &str, conversation_id: &str) -> Result<(), String> {
+        self.stopped_convs.lock().unwrap().push(conversation_id.to_owned());
+        if self.fail.contains(conversation_id) {
+            return Err(format!("forced teardown failure {conversation_id}"));
+        }
+        Ok(())
+    }
+
+    async fn stop_team(&self, _user_id: &str, team_id: &str) -> Result<(), String> {
+        self.stopped_teams.lock().unwrap().push(team_id.to_owned());
+        if self.fail.contains(team_id) {
+            return Err(format!("forced teardown failure {team_id}"));
+        }
+        Ok(())
+    }
+}
+
 /// A `user_order` store over the same pool the service uses — `SqliteUserOrderStore`
 /// is stateless over the pool, so a fresh instance behaves identically.
 fn uo_store(pool: &SqlitePool) -> Arc<dyn IUserOrderStore> {
@@ -1213,6 +1252,86 @@ async fn archive_conversation_moves_slice_and_unpins() {
         vec!["c1"],
         "surfaces in archive"
     );
+}
+
+/// Archiving a conversation tears down its agent process (like delete) but,
+/// unlike delete, keeps the row: only `archived_at` flips, the conversation is
+/// still on disk (unarchiving cold-starts a fresh agent).
+#[tokio::test]
+async fn archive_conversation_tears_down_process_but_keeps_row() {
+    let fx = fixture().await;
+    let pool = fx.pool();
+    insert_conv(pool, USER, "c1", None, "{}", 100).await;
+    let teardown = FakeTeardownPorts::new(&[]);
+    fx.service.set_archive_teardown_ports(teardown.clone());
+
+    fx.service.archive_conversation(USER, "c1").await.unwrap();
+
+    assert_eq!(
+        *teardown.stopped_convs.lock().unwrap(),
+        vec!["c1"],
+        "archive stops the agent process"
+    );
+    assert!(teardown.stopped_teams.lock().unwrap().is_empty(), "no team teardown");
+    assert!(conv_exists(pool, "c1").await, "row preserved (data not deleted)");
+    assert!(conv_archived_at(pool, "c1").await.is_some(), "only archived_at flipped");
+}
+
+/// Archiving a team tears down its runtime + member agents (like delete) but
+/// keeps every row: team and folded members only get `archived_at`.
+#[tokio::test]
+async fn archive_team_tears_down_runtime_but_keeps_rows() {
+    let fx = fixture().await;
+    let pool = fx.pool();
+    insert_team(pool, USER, "T1", "", None, 100).await;
+    insert_member(pool, USER, "m1", "T1", 90).await;
+    let teardown = FakeTeardownPorts::new(&[]);
+    fx.service.set_archive_teardown_ports(teardown.clone());
+
+    fx.service.archive_team(USER, "T1").await.unwrap();
+
+    assert_eq!(
+        *teardown.stopped_teams.lock().unwrap(),
+        vec!["T1"],
+        "archive stops the team runtime (member kills happen inside the team service)"
+    );
+    assert!(
+        teardown.stopped_convs.lock().unwrap().is_empty(),
+        "team teardown is one call, not per-member from the sidebar"
+    );
+    assert!(
+        team_archived_at(pool, "T1").await.is_some(),
+        "team row preserved + archived"
+    );
+    assert!(conv_exists(pool, "m1").await, "member row preserved");
+    assert!(
+        conv_archived_at(pool, "m1").await.is_some(),
+        "member archived_at flipped"
+    );
+}
+
+/// Teardown is best-effort: a failing stop only warns, so the archive flip
+/// still succeeds (the row already moved slice — a lingering process is a leak
+/// to log, not a reason to fail the archive).
+#[tokio::test]
+async fn archive_succeeds_even_when_teardown_fails() {
+    let fx = fixture().await;
+    let pool = fx.pool();
+    insert_conv(pool, USER, "c1", None, "{}", 100).await;
+    let teardown = FakeTeardownPorts::new(&["c1"]); // forced teardown failure
+    fx.service.set_archive_teardown_ports(teardown.clone());
+
+    fx.service
+        .archive_conversation(USER, "c1")
+        .await
+        .expect("archive still succeeds despite teardown failure");
+
+    assert_eq!(
+        *teardown.stopped_convs.lock().unwrap(),
+        vec!["c1"],
+        "teardown attempted"
+    );
+    assert!(conv_archived_at(pool, "c1").await.is_some(), "flip committed anyway");
 }
 
 /// Archiving an unknown id, or another user's conversation, is a 404

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -879,22 +879,8 @@ impl TeamSessionService {
     pub async fn remove_team(&self, user_id: &str, team_id: &str) -> Result<(), TeamError> {
         let team = self.load_owned_team(user_id, team_id).await?;
 
-        self.stop_session_unchecked(team_id);
-
-        let kill_futures: Vec<_> = team
-            .agents
-            .iter()
-            .map(|agent| {
-                self.task_manager
-                    .kill_and_wait(&agent.conversation_id, Some(AgentKillReason::TeamDeleted))
-            })
-            .collect();
-
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            futures_util::future::join_all(kill_futures),
-        )
-        .await;
+        self.stop_team_runtime_and_agents(team_id, &team, AgentKillReason::TeamDeleted)
+            .await;
 
         for agent in &team.agents {
             let _ = self
@@ -918,6 +904,38 @@ impl TeamSessionService {
 
         info!(team_id = %team_id, "Team removed");
         self.broadcast_team_removed(user_id, team_id);
+        Ok(())
+    }
+
+    /// Tear down a team's live runtime and every member agent process WITHOUT
+    /// deleting any data. Shared by `remove_team` (which then drops the rows)
+    /// and `stop_team_processes` (archive, which keeps them). Best-effort: a
+    /// stuck kill is bounded by a 3s timeout, mirroring the delete path.
+    async fn stop_team_runtime_and_agents(&self, team_id: &str, team: &Team, reason: AgentKillReason) {
+        self.stop_session_unchecked(team_id);
+
+        let kill_futures: Vec<_> = team
+            .agents
+            .iter()
+            .map(|agent| self.task_manager.kill_and_wait(&agent.conversation_id, Some(reason)))
+            .collect();
+
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            futures_util::future::join_all(kill_futures),
+        )
+        .await;
+    }
+
+    /// Archive-time teardown: stop the team runtime and kill every member agent
+    /// process, but keep all rows intact (the archive flip lives in the sidebar
+    /// service). Mirrors the process-stopping half of `remove_team` so an
+    /// archived team stops streaming just like a deleted one; unarchiving
+    /// cold-starts a fresh runtime.
+    pub async fn stop_team_processes(&self, user_id: &str, team_id: &str) -> Result<(), TeamError> {
+        let team = self.load_owned_team(user_id, team_id).await?;
+        self.stop_team_runtime_and_agents(team_id, &team, AgentKillReason::Archived)
+            .await;
         Ok(())
     }
 

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -2930,6 +2930,85 @@ async fn tc1_create_team_with_multiple_agents() {
     assert_eq!(resp.leader_assistant_id, Some(resp.assistants[0].slot_id.clone()));
 }
 
+/// Archive-time teardown: `stop_team_processes` kills every member agent with
+/// the `Archived` reason and stops the runtime, but deletes NOTHING — the team
+/// and its members are still readable afterward (unarchiving cold-starts fresh).
+/// Mirrors the process-stopping half of `remove_team` without the deletes.
+#[tokio::test]
+async fn stop_team_processes_kills_members_but_keeps_rows() {
+    let (svc, _team_repo, task_manager, _conv_repo) = setup_with_factory_metadata_team_repo_and_conversation_repo(
+        success_factory(),
+        Arc::new(StubAgentMetadataRepo::empty()),
+    );
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Teardown Team".into(),
+                agents: two_agent_input(),
+                workspace: None,
+            },
+        )
+        .await
+        .expect("create team");
+    task_manager.reset_calls();
+
+    svc.stop_team_processes("user1", &created.id)
+        .await
+        .expect("stop team processes");
+
+    // Every member agent was killed with the Archived reason.
+    let killed = task_manager.snapshot().kill;
+    for agent in &created.assistants {
+        assert!(
+            killed
+                .iter()
+                .any(|(id, reason)| id == &agent.conversation_id && matches!(reason, Some(AgentKillReason::Archived))),
+            "member {} killed with Archived reason; kills = {killed:?}",
+            agent.conversation_id
+        );
+    }
+
+    // Nothing was deleted: the team and its members are still readable.
+    let still_there = svc.get_team("user1", &created.id).await.expect("team row preserved");
+    assert_eq!(
+        still_there.assistants.len(),
+        created.assistants.len(),
+        "all member rows preserved"
+    );
+}
+
+/// Teardown is owner-scoped: an unknown or foreign team is `TeamNotFound` and
+/// kills nothing (no cross-user process teardown).
+#[tokio::test]
+async fn stop_team_processes_rejects_unknown_or_foreign_team() {
+    let (svc, _team_repo, task_manager, _conv_repo) = setup_with_factory_metadata_team_repo_and_conversation_repo(
+        success_factory(),
+        Arc::new(StubAgentMetadataRepo::empty()),
+    );
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Owned".into(),
+                agents: two_agent_input(),
+                workspace: None,
+            },
+        )
+        .await
+        .expect("create team");
+    task_manager.reset_calls();
+
+    let err = svc.stop_team_processes("other-user", &created.id).await.unwrap_err();
+    assert!(matches!(err, TeamError::TeamNotFound(_)), "foreign team → 404: {err:?}");
+    let err = svc.stop_team_processes("user1", "no-such-team").await.unwrap_err();
+    assert!(matches!(err, TeamError::TeamNotFound(_)), "unknown team → 404: {err:?}");
+    assert!(
+        task_manager.snapshot().kill.is_empty(),
+        "no agent killed on a rejected teardown"
+    );
+}
+
 #[tokio::test]
 async fn create_team_rejects_existing_conversation_id_request_side_adoption() {
     let svc = setup();


### PR DESCRIPTION
## What & why

Archiving a conversation/team used to only flip `archived_at` — the agent process kept running as a child of the backend, streaming for a unit the user just moved out of the active workspace. Deleting, by contrast, tears the process down. This aligns archive teardown with delete: **stop the agent runtime the same way delete does, but keep all data** (only `archived_at` flips; rows and history survive, so unarchiving cold-starts a fresh agent).

## Changes

- **`AgentKillReason::Archived`** + its user-facing close message (the one exhaustive match on the enum).
- **Team** (`aionui-team`): extract `stop_team_runtime_and_agents` shared by `remove_team` (reason `TeamDeleted`, then deletes rows) and the new **`stop_team_processes`** (reason `Archived`, stop-only — no `repo.delete_*`). Owner-scoped via `load_owned_team`.
- **Sidebar** (`aionui-sidebar`): new `ArchiveTeardownPorts` seam (`stop_conversation` / `stop_team`), driven **best-effort** from `archive_conversation` / `archive_team` after the flip commits — a failed teardown only warns, never fails the archive.
- **Composition** (`aionui-app`): `ArchiveTeardownAdapter` wired via set-once late injection (worker task manager kill + team stop).
- **Frontend: zero changes** — conversation-level archive (single/batch/project) already loops per-conversation; team-level archive triggers one team teardown.

## Tests

- Sidebar: archive stops process/runtime but **keeps rows**; archive still succeeds when teardown fails.
- Team: `stop_team_processes` kills members with `Archived` reason yet preserves rows; rejects foreign/unknown teams (`TeamNotFound`), killing nothing.

## Verification

`just push` full gate green: **9203 tests passed, 0 failed** (workspace), clippy/fmt clean. Not yet live-verified in the desktop app.