### PR TITLE
feat(auth): dual-token refresh with singleflight

### DIFF
--- a/crates/aionui-api-types/src/auth.rs
+++ b/crates/aionui-api-types/src/auth.rs
@@ -72,10 +72,15 @@ pub struct UserInfoResponse {
 }
 
 /// Refresh token response for `POST /api/auth/refresh`.
+///
+/// `token` is the new access token; `refresh_token` is the rotated refresh
+/// token. Native clients persist both and renew via the request body; browsers
+/// ignore `refresh_token` and rely on the `Set-Cookie`d refresh cookie instead.
 #[derive(Debug, Serialize)]
 pub struct RefreshResponse {
     pub success: bool,
     pub token: String,
+    pub refresh_token: String,
 }
 
 /// WebSocket token response for `GET /api/ws-token`.
@@ -384,5 +389,20 @@ mod tests {
         let raw = r#"{}"#;
         let result = serde_json::from_str::<RefreshTokenRequest>(raw);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_refresh_response_carries_both_tokens() {
+        // Native clients migrating to the dual-token model must be able to read
+        // the rotated refresh token out of the JSON body.
+        let resp = RefreshResponse {
+            success: true,
+            token: "access.jwt".into(),
+            refresh_token: "refresh.jwt".into(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["token"], "access.jwt");
+        assert_eq!(json["refresh_token"], "refresh.jwt");
     }
 }

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -20,8 +20,8 @@ use aionui_api_types::{ErrorResponse, WebSocketMessage};
 use aionui_assets::{AssetRouterState, asset_routes};
 use aionui_assistant::assistant_routes;
 use aionui_auth::{
-    AuthIdentityMode, AuthRouterState, AuthState, IRuntimeTokenVerifier, SystemDefaultFilesystemAdopter,
-    auth_middleware, auth_routes, csrf_middleware, security_headers_middleware,
+    AuthIdentityMode, AuthRouterState, AuthState, IRuntimeTokenVerifier, RefreshCoalescer,
+    SystemDefaultFilesystemAdopter, auth_middleware, auth_routes, csrf_middleware, security_headers_middleware,
 };
 use aionui_channel::channel_routes;
 #[cfg(feature = "weixin")]
@@ -208,6 +208,7 @@ pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates
 
     let auth_state = AuthRouterState {
         jwt_service: services.jwt_service.clone(),
+        refresh_coalescer: RefreshCoalescer::new(),
         user_repo: services.user_repo.clone(),
         fs_adopter: Some(Arc::new(SkillFilesystemAdopter {
             skill_paths: services.skill_paths.clone(),

--- a/crates/aionui-auth/src/cookie.rs
+++ b/crates/aionui-auth/src/cookie.rs
@@ -1,4 +1,7 @@
-use aionui_common::constants::{COOKIE_MAX_AGE_DAYS, COOKIE_NAME, CSRF_COOKIE_NAME};
+use aionui_common::constants::{
+    COOKIE_MAX_AGE_DAYS, COOKIE_NAME, CSRF_COOKIE_NAME, REFRESH_COOKIE_MAX_AGE_DAYS, REFRESH_COOKIE_NAME,
+    REFRESH_COOKIE_PATH,
+};
 
 /// Cookie security configuration derived from the deployment environment.
 #[derive(Debug, Clone)]
@@ -53,6 +56,34 @@ impl CookieConfig {
         let max_age = u64::from(COOKIE_MAX_AGE_DAYS) * 24 * 60 * 60;
         format!(
             "{CSRF_COOKIE_NAME}={token}; Path=/; SameSite={}{}; Max-Age={max_age}",
+            self.same_site,
+            if self.secure { "; Secure" } else { "" },
+        )
+    }
+
+    /// Build `Set-Cookie` header value for the refresh token.
+    ///
+    /// Scoped to [`REFRESH_COOKIE_PATH`] so the browser only attaches it when
+    /// calling the refresh endpoint — keeping this long-lived credential off
+    /// every ordinary API/WebSocket request. Always `HttpOnly`: unlike the CSRF
+    /// cookie, JavaScript must never read the refresh token.
+    pub fn build_refresh_cookie(&self, token: &str) -> String {
+        let max_age = u64::from(REFRESH_COOKIE_MAX_AGE_DAYS) * 24 * 60 * 60;
+        format!(
+            "{REFRESH_COOKIE_NAME}={token}; Path={REFRESH_COOKIE_PATH}; HttpOnly; SameSite={}{}; Max-Age={max_age}",
+            self.same_site,
+            if self.secure { "; Secure" } else { "" },
+        )
+    }
+
+    /// Build `Set-Cookie` header value that clears the refresh cookie.
+    ///
+    /// Must repeat the exact `Path` of [`CookieConfig::build_refresh_cookie`]:
+    /// browsers match deletion on name + path, so a mismatched path would leave
+    /// the refresh cookie in place.
+    pub fn clear_refresh_cookie(&self) -> String {
+        format!(
+            "{REFRESH_COOKIE_NAME}=; Path={REFRESH_COOKIE_PATH}; HttpOnly; SameSite={}{}; Max-Age=0",
             self.same_site,
             if self.secure { "; Secure" } else { "" },
         )
@@ -124,5 +155,48 @@ mod tests {
         let cookie = http_config().build_session_cookie("t");
         let expected = 30 * 24 * 60 * 60;
         assert!(cookie.contains(&format!("Max-Age={expected}")));
+    }
+
+    #[test]
+    fn refresh_cookie_http() {
+        let cookie = http_config().build_refresh_cookie("refresh_token");
+        assert!(cookie.contains("aionui-refresh=refresh_token"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains("Max-Age="));
+        assert!(!cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn refresh_cookie_https() {
+        let cookie = https_config().build_refresh_cookie("refresh_token");
+        assert!(cookie.contains("SameSite=Strict"));
+        assert!(cookie.contains("; Secure"));
+    }
+
+    #[test]
+    fn refresh_cookie_is_scoped_to_refresh_path() {
+        // The long-lived credential must not ride along on every request: it is
+        // pinned to the refresh endpoint's path, never the root path.
+        let cookie = http_config().build_refresh_cookie("t");
+        assert!(cookie.contains("Path=/api/auth/refresh"));
+        assert!(!cookie.contains("Path=/;"));
+    }
+
+    #[test]
+    fn refresh_cookie_max_age_30_days() {
+        let cookie = http_config().build_refresh_cookie("t");
+        let expected = 30 * 24 * 60 * 60;
+        assert!(cookie.contains(&format!("Max-Age={expected}")));
+    }
+
+    #[test]
+    fn clear_refresh_cookie_sets_max_age_zero_on_same_path() {
+        let cookie = http_config().clear_refresh_cookie();
+        assert!(cookie.contains("aionui-refresh="));
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("HttpOnly"));
+        // Deletion only takes effect when the path matches the set cookie.
+        assert!(cookie.contains("Path=/api/auth/refresh"));
     }
 }

--- a/crates/aionui-auth/src/jwt.rs
+++ b/crates/aionui-auth/src/jwt.rs
@@ -8,22 +8,48 @@ use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode}
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use aionui_common::constants::REFRESH_COOKIE_MAX_AGE_DAYS;
+
 use crate::error::AuthError;
 
-/// JWT token lifetime: 30 days.
+/// Access-token lifetime.
 ///
-/// Stop-gap value aligned with the session cookie's `Max-Age`
-/// (`COOKIE_MAX_AGE_DAYS`). The cookie shell used to outlive this JWT, so after
-/// the previous 24h expiry every request carried a dead token, producing the
-/// 401/reconnect loop seen on remote WebUI. This stays long until token refresh
-/// lands, after which it returns to a short access-token lifetime.
-const TOKEN_EXPIRY: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+/// Still 30 days as a stop-gap for #4124: before the refresh flow exists,
+/// shortening it would reintroduce the 401/reconnect loop on remote WebUI (a
+/// dead token on every request with no way to renew). It drops to a short
+/// lifetime only once clients consume the refresh flow end-to-end — an
+/// intentional, later contract change, not a regression.
+const ACCESS_TOKEN_EXPIRY: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Refresh-token lifetime — the window a session can be renewed without
+/// re-authenticating. Sliding: each refresh issues a fresh refresh token.
+/// Kept in sync with the refresh cookie's `Max-Age` so the token never outlives
+/// (or is outlived by) its container.
+const REFRESH_TOKEN_EXPIRY: Duration = Duration::from_secs(REFRESH_COOKIE_MAX_AGE_DAYS as u64 * 24 * 60 * 60);
 
 /// JWT issuer claim value.
 const JWT_ISSUER: &str = "aionui";
 
 /// JWT audience claim value.
 const JWT_AUDIENCE: &str = "aionui-webui";
+
+/// Which credential role a token fills.
+///
+/// Access tokens authenticate ordinary API/WebSocket requests; refresh tokens
+/// are accepted only at the refresh endpoint to mint new access tokens. Keeping
+/// the roles distinct means a leaked short-lived access token can never be
+/// replayed as a long-lived refresh credential, and a refresh token can never
+/// be used to call protected endpoints directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TokenType {
+    /// Short-lived credential for authenticating requests. Default so tokens
+    /// issued before this field existed deserialize as access tokens.
+    #[default]
+    Access,
+    /// Long-lived credential accepted only by the refresh endpoint.
+    Refresh,
+}
 
 /// JWT payload (claims embedded in the token).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +69,9 @@ pub struct TokenPayload {
     /// User session generation at token issuance time.
     #[serde(default)]
     pub session_generation: i64,
+    /// Credential role: access (default) vs refresh.
+    #[serde(default)]
+    pub token_type: TokenType,
 }
 
 /// JWT service for signing, verification, and token blacklisting.
@@ -66,20 +95,58 @@ impl JwtService {
         }
     }
 
-    /// Sign a new JWT for the given user. The token expires after 30 days.
+    /// Sign a new access JWT for the given user. Convenience for callers that
+    /// do not track a session generation (tests, local mode).
     pub fn sign(&self, user_id: &str, username: &str) -> Result<String, AuthError> {
         self.sign_with_session_generation(user_id, username, 0)
     }
 
-    /// Sign a new JWT bound to the user's current session generation.
+    /// Sign an access JWT bound to the user's current session generation.
+    ///
+    /// Access tokens authenticate ordinary requests and carry the
+    /// [`ACCESS_TOKEN_EXPIRY`]. Pair with [`JwtService::sign_refresh`] to also
+    /// issue the long-lived refresh token used to renew this one.
     pub fn sign_with_session_generation(
         &self,
         user_id: &str,
         username: &str,
         session_generation: i64,
     ) -> Result<String, AuthError> {
+        self.sign_claims(
+            user_id,
+            username,
+            session_generation,
+            TokenType::Access,
+            ACCESS_TOKEN_EXPIRY,
+        )
+    }
+
+    /// Sign a refresh JWT bound to the user's current session generation.
+    ///
+    /// Accepted only by the refresh endpoint (enforced via
+    /// [`JwtService::verify_refresh`]), never as a request credential. Carries
+    /// the long [`REFRESH_TOKEN_EXPIRY`].
+    pub fn sign_refresh(&self, user_id: &str, username: &str, session_generation: i64) -> Result<String, AuthError> {
+        self.sign_claims(
+            user_id,
+            username,
+            session_generation,
+            TokenType::Refresh,
+            REFRESH_TOKEN_EXPIRY,
+        )
+    }
+
+    /// Encode a signed JWT for the given credential role and lifetime.
+    fn sign_claims(
+        &self,
+        user_id: &str,
+        username: &str,
+        session_generation: i64,
+        token_type: TokenType,
+        ttl: Duration,
+    ) -> Result<String, AuthError> {
         let now = now_secs()?;
-        let exp = now + TOKEN_EXPIRY.as_secs();
+        let exp = now + ttl.as_secs();
 
         let claims = TokenPayload {
             user_id: user_id.to_owned(),
@@ -89,6 +156,7 @@ impl JwtService {
             iss: JWT_ISSUER.to_owned(),
             aud: JWT_AUDIENCE.to_owned(),
             session_generation,
+            token_type,
         };
 
         let secret = self
@@ -131,6 +199,30 @@ impl JwtService {
         Ok(token_data.claims)
     }
 
+    /// Verify a token and require it to be a [`TokenType::Access`] token.
+    ///
+    /// Used on the request-authentication path so a refresh token cannot be
+    /// replayed as a request credential.
+    pub fn verify_access(&self, token: &str) -> Result<TokenPayload, AuthError> {
+        let payload = self.verify(token)?;
+        if payload.token_type != TokenType::Access {
+            return Err(AuthError::TokenInvalid("expected an access token".into()));
+        }
+        Ok(payload)
+    }
+
+    /// Verify a token and require it to be a [`TokenType::Refresh`] token.
+    ///
+    /// Used by the refresh endpoint so an access token cannot be exchanged for
+    /// a renewed session.
+    pub fn verify_refresh(&self, token: &str) -> Result<TokenPayload, AuthError> {
+        let payload = self.verify(token)?;
+        if payload.token_type != TokenType::Refresh {
+            return Err(AuthError::TokenInvalid("expected a refresh token".into()));
+        }
+        Ok(payload)
+    }
+
     /// Add a token to the blacklist.
     ///
     /// Stores the token's SHA-256 hash with its expiry time for automatic cleanup.
@@ -138,7 +230,9 @@ impl JwtService {
         let hash = token_hash(token);
         let exp = self
             .extract_expiry(token)
-            .unwrap_or_else(|| now_secs().unwrap_or(0) + TOKEN_EXPIRY.as_secs());
+            // Fallback when the token cannot be parsed: keep the entry at least
+            // as long as the longest-lived token could survive.
+            .unwrap_or_else(|| now_secs().unwrap_or(0) + REFRESH_TOKEN_EXPIRY.as_secs());
         self.blacklist.insert(hash, exp);
     }
 
@@ -299,7 +393,7 @@ mod tests {
         let service = test_service();
         let token = service.sign("user_1", "admin").unwrap();
         let payload = service.verify(&token).unwrap();
-        assert_eq!(TOKEN_EXPIRY.as_secs(), 30 * 24 * 60 * 60);
+        assert_eq!(ACCESS_TOKEN_EXPIRY.as_secs(), 30 * 24 * 60 * 60);
         assert_eq!(payload.exp - payload.iat, 30 * 24 * 60 * 60);
     }
 
@@ -341,6 +435,7 @@ mod tests {
             iss: JWT_ISSUER.into(),
             aud: JWT_AUDIENCE.into(),
             session_generation: 0,
+            token_type: TokenType::Access,
         };
         let token = encode(
             &Header::default(),
@@ -423,6 +518,7 @@ mod tests {
             iss: JWT_ISSUER.into(),
             aud: JWT_AUDIENCE.into(),
             session_generation: 0,
+            token_type: TokenType::Access,
         };
         let token = encode(
             &Header::default(),
@@ -555,5 +651,101 @@ mod tests {
         let h = token_hash("test");
         assert_eq!(h.len(), 64);
         assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn access_token_carries_access_type() {
+        let service = test_service();
+        let token = service.sign_with_session_generation("user_1", "admin", 0).unwrap();
+        let payload = service.verify(&token).unwrap();
+        assert_eq!(payload.token_type, TokenType::Access);
+    }
+
+    #[test]
+    fn sign_refresh_produces_refresh_token() {
+        let service = test_service();
+        let token = service.sign_refresh("user_1", "admin", 3).unwrap();
+        let payload = service.verify(&token).unwrap();
+        assert_eq!(payload.token_type, TokenType::Refresh);
+        assert_eq!(payload.user_id, "user_1");
+        assert_eq!(payload.session_generation, 3);
+        // Refresh lifetime is kept in sync with the refresh cookie's Max-Age.
+        assert_eq!(payload.exp - payload.iat, REFRESH_TOKEN_EXPIRY.as_secs());
+    }
+
+    #[test]
+    fn verify_access_accepts_access_but_rejects_refresh() {
+        let service = test_service();
+        let access = service.sign("user_1", "admin").unwrap();
+        let refresh = service.sign_refresh("user_1", "admin", 0).unwrap();
+
+        // An access token is accepted on the request path.
+        assert!(service.verify_access(&access).is_ok());
+
+        // A refresh token must never authenticate an ordinary request.
+        let err = service.verify_access(&refresh).unwrap_err();
+        assert!(
+            matches!(&err, AuthError::TokenInvalid(msg) if msg == "expected an access token"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_refresh_accepts_refresh_but_rejects_access() {
+        let service = test_service();
+        let access = service.sign("user_1", "admin").unwrap();
+        let refresh = service.sign_refresh("user_1", "admin", 0).unwrap();
+
+        // A refresh token is accepted at the refresh endpoint.
+        assert!(service.verify_refresh(&refresh).is_ok());
+
+        // An access token cannot be exchanged for a renewed session.
+        let err = service.verify_refresh(&access).unwrap_err();
+        assert!(
+            matches!(&err, AuthError::TokenInvalid(msg) if msg == "expected a refresh token"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_token_without_type_defaults_to_access() {
+        // A token minted before `token_type` existed carries no such claim. It
+        // must deserialize as an access token (serde default) so pre-upgrade
+        // sessions keep authenticating instead of being rejected as "not an
+        // access token".
+        #[derive(Serialize)]
+        struct LegacyClaims {
+            user_id: String,
+            username: String,
+            iat: u64,
+            exp: u64,
+            iss: String,
+            aud: String,
+            session_generation: i64,
+        }
+
+        let service = test_service();
+        let now = now_secs().unwrap();
+        let secret = service.secret.read().unwrap();
+        let token = encode(
+            &Header::default(),
+            &LegacyClaims {
+                user_id: "user_1".into(),
+                username: "admin".into(),
+                iat: now,
+                exp: now + 3600,
+                iss: JWT_ISSUER.into(),
+                aud: JWT_AUDIENCE.into(),
+                session_generation: 0,
+            },
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap();
+        drop(secret);
+
+        let payload = service.verify(&token).unwrap();
+        assert_eq!(payload.token_type, TokenType::Access);
+        // And it is therefore usable on the request-authentication path.
+        assert!(service.verify_access(&token).is_ok());
     }
 }

--- a/crates/aionui-auth/src/lib.rs
+++ b/crates/aionui-auth/src/lib.rs
@@ -15,6 +15,7 @@ mod routes;
 mod secret;
 mod security;
 mod service;
+mod singleflight;
 mod validation;
 
 // Error type
@@ -69,6 +70,9 @@ pub use middleware::{
 
 // QR token store
 pub use qr_token::QrTokenStore;
+
+// Refresh-storm coalescing (shared into AuthRouterState)
+pub use singleflight::RefreshCoalescer;
 
 // Routes
 pub use routes::{AuthRouterState, SessionRevokedHook, auth_routes};

--- a/crates/aionui-auth/src/middleware.rs
+++ b/crates/aionui-auth/src/middleware.rs
@@ -105,7 +105,9 @@ pub async fn auth_middleware(
         return runtime_token_channel(&state, request, next).await;
     };
 
-    let payload = state.jwt_service.verify(&token).map_err(|e| {
+    // Require an *access* token here: a refresh token must never authenticate an
+    // ordinary request — it is accepted only at the refresh endpoint.
+    let payload = state.jwt_service.verify_access(&token).map_err(|e| {
         tracing::debug!("Token verification failed: {e}");
         ApiError::Unauthorized("Invalid or expired token".into())
     })?;

--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -7,7 +7,7 @@ use axum::extract::rejection::JsonRejection;
 use axum::extract::{Json, Path, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::middleware::from_fn_with_state;
-use axum::response::{Html, IntoResponse, Response};
+use axum::response::{AppendHeaders, Html, IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::{Extension, Router};
 use serde::{Deserialize, Serialize};
@@ -20,11 +20,11 @@ use aionui_api_types::{
     WebuiResetPasswordResponse, WsTokenResponse,
 };
 use aionui_common::ApiError;
-use aionui_common::constants::COOKIE_MAX_AGE_DAYS;
+use aionui_common::constants::{COOKIE_MAX_AGE_DAYS, REFRESH_COOKIE_NAME};
 use aionui_db::{DbError, IUserRepository, UserStatus, UserType, models::User};
 
 use crate::error::AuthError;
-use crate::extract::extract_token_from_headers;
+use crate::extract::{extract_cookie_value, extract_token_from_headers};
 use crate::middleware::{AuthIdentityMode, AuthState, CurrentUser, auth_middleware};
 use crate::password::{dummy_password_hash, generate_password, hash_password, verify_password_timed};
 use crate::qr_token::QrTokenStore;
@@ -32,6 +32,7 @@ use crate::rate_limit::{
     RateLimiter, api_rate_limit_middleware, auth_rate_limit_middleware, authenticated_action_rate_limit_middleware,
 };
 use crate::service::{AuthProvisionService, ProvisionError};
+use crate::singleflight::{RefreshCoalescer, RefreshError, RefreshedTokens};
 use crate::validation::{validate_password, validate_username};
 use crate::{CookieConfig, JwtService};
 
@@ -54,6 +55,16 @@ impl From<AuthError> for ApiError {
     }
 }
 
+impl From<RefreshError> for ApiError {
+    fn from(err: RefreshError) -> Self {
+        match err {
+            RefreshError::Unauthorized(msg) => ApiError::Unauthorized(msg.into()),
+            RefreshError::UserContextRequired => user_context_required(),
+            RefreshError::Internal(msg) => ApiError::Internal(msg.into()),
+        }
+    }
+}
+
 fn db_error_to_api_error(err: DbError) -> ApiError {
     match err {
         DbError::NotFound(msg) => ApiError::NotFound(msg),
@@ -68,6 +79,8 @@ fn db_error_to_api_error(err: DbError) -> ApiError {
 #[derive(Clone)]
 pub struct AuthRouterState {
     pub jwt_service: Arc<JwtService>,
+    /// Coalesces concurrent refreshes for the same token (refresh-storm guard).
+    pub refresh_coalescer: RefreshCoalescer,
     pub user_repo: Arc<dyn IUserRepository>,
     /// Optional on-disk adoption side-effect (AionUi → AionPro upgrade).
     pub fs_adopter: Option<Arc<dyn crate::service::SystemDefaultFilesystemAdopter>>,
@@ -403,8 +416,16 @@ async fn create_external_session_handler(
         user_id = %exchange.response.user.id,
         "external core session exchange succeeded"
     );
-    let cookie = state.cookie_config.build_session_cookie(&exchange.token);
-    Ok(([(header::SET_COOKIE, cookie)], Json(ApiResponse::ok(exchange.response))).into_response())
+    let session_cookie = state.cookie_config.build_session_cookie(&exchange.token);
+    let refresh_cookie = state.cookie_config.build_refresh_cookie(&exchange.refresh_token);
+    Ok((
+        AppendHeaders([
+            (header::SET_COOKIE, session_cookie),
+            (header::SET_COOKIE, refresh_cookie),
+        ]),
+        Json(ApiResponse::ok(exchange.response)),
+    )
+        .into_response())
 }
 
 // ---------------------------------------------------------------------------
@@ -500,13 +521,22 @@ async fn login_handler(
             user.session_generation,
         )
         .map_err(|e| ApiError::Internal(format!("Token signing error: {e}")))?;
+    let refresh_token = state
+        .jwt_service
+        .sign_refresh(
+            &user.id,
+            user.username.as_deref().unwrap_or("external_user"),
+            user.session_generation,
+        )
+        .map_err(|e| ApiError::Internal(format!("Token signing error: {e}")))?;
 
     // Update last login (best-effort)
     if let Err(e) = state.user_repo.update_last_login(&user.id).await {
         tracing::warn!("Failed to update last login for {}: {e}", user.id);
     }
 
-    let cookie = state.cookie_config.build_session_cookie(&token);
+    let session_cookie = state.cookie_config.build_session_cookie(&token);
+    let refresh_cookie = state.cookie_config.build_refresh_cookie(&refresh_token);
     let resp = LoginResponse::new(
         PublicUser {
             id: user.id,
@@ -515,7 +545,14 @@ async fn login_handler(
         token,
     );
 
-    Ok(([(header::SET_COOKIE, cookie)], Json(resp)).into_response())
+    Ok((
+        AppendHeaders([
+            (header::SET_COOKIE, session_cookie),
+            (header::SET_COOKIE, refresh_cookie),
+        ]),
+        Json(resp),
+    )
+        .into_response())
 }
 
 // ---------------------------------------------------------------------------
@@ -527,10 +564,22 @@ async fn logout_handler(State(state): State<AuthRouterState>, headers: HeaderMap
         state.jwt_service.blacklist_token(&token);
     }
 
-    let cookie = state.cookie_config.clear_session_cookie();
+    // Clear both credential cookies. The refresh cookie is path-scoped to the
+    // refresh endpoint, so the browser does not send it here to be blacklisted;
+    // clearing it drops it client-side, and full server-side revocation is via
+    // the user's session generation (password change / session revoke).
+    let session_cookie = state.cookie_config.clear_session_cookie();
+    let refresh_cookie = state.cookie_config.clear_refresh_cookie();
     let resp = ApiResponse::message("Logged out successfully");
 
-    Ok(([(header::SET_COOKIE, cookie)], Json(resp)).into_response())
+    Ok((
+        AppendHeaders([
+            (header::SET_COOKIE, session_cookie),
+            (header::SET_COOKIE, refresh_cookie),
+        ]),
+        Json(resp),
+    )
+        .into_response())
 }
 
 // ---------------------------------------------------------------------------
@@ -553,9 +602,10 @@ async fn status_handler(
         .await
         .map_err(|e| ApiError::Internal(format!("Database error: {e}")))?;
 
-    // Check authentication without requiring it
+    // Check authentication without requiring it. Only an access token counts as
+    // "authenticated" — a refresh token is not a request credential.
     let is_authenticated = extract_token_from_headers(&headers)
-        .and_then(|token| state.jwt_service.verify(&token).ok())
+        .and_then(|token| state.jwt_service.verify_access(&token).ok())
         .is_some();
 
     Ok(Json(AuthStatusResponse {
@@ -776,14 +826,63 @@ async fn change_password_handler(
 
 async fn refresh_handler(
     State(state): State<AuthRouterState>,
+    headers: HeaderMap,
     body: Result<Json<RefreshTokenRequest>, JsonRejection>,
-) -> Result<Json<RefreshResponse>, ApiError> {
-    let Json(req) = body.map_err(ApiError::from)?;
+) -> Result<Response, ApiError> {
+    // Prefer the HttpOnly refresh cookie; fall back to the request body for
+    // legacy clients that posted the token explicitly.
+    let (raw_token, from_cookie) = match extract_cookie_value(&headers, REFRESH_COOKIE_NAME) {
+        Some(cookie_token) => (cookie_token, true),
+        None => {
+            let Json(req) = body.map_err(ApiError::from)?;
+            (req.token, false)
+        }
+    };
 
-    let payload = state
-        .jwt_service
-        .verify(&req.token)
-        .map_err(|_| ApiError::Unauthorized("Invalid or expired token".into()))?;
+    // Coalesce concurrent refreshes carrying the same token: one expired access
+    // token can fail many in-flight requests at once, and without this each
+    // would independently hit the database and re-sign, stampeding the hottest
+    // auth path. Same token -> one execution, shared result.
+    let tokens = state
+        .refresh_coalescer
+        .run(&raw_token, || refresh_tokens(&state, &raw_token, from_cookie))
+        .await?;
+
+    let session_cookie = state.cookie_config.build_session_cookie(&tokens.access);
+    let refresh_cookie = state.cookie_config.build_refresh_cookie(&tokens.refresh);
+    Ok((
+        AppendHeaders([
+            (header::SET_COOKIE, session_cookie),
+            (header::SET_COOKIE, refresh_cookie),
+        ]),
+        Json(RefreshResponse {
+            success: true,
+            token: tokens.access,
+            refresh_token: tokens.refresh,
+        }),
+    )
+        .into_response())
+}
+
+/// Verify a refresh request and mint a fresh access + refresh token pair.
+///
+/// A cookie-borne token must be a refresh token (`verify_refresh`); the legacy
+/// body path stays lenient (`verify`) because older clients posted their access
+/// session token here. Runs behind [`RefreshCoalescer`] so an expiry storm
+/// collapses into a single execution — hence the crate-owned [`RefreshError`]:
+/// it is `Clone`, so one execution's outcome (success *or* failure) can be
+/// shared by every coalesced caller, and the route layer maps it to `ApiError`.
+async fn refresh_tokens(
+    state: &AuthRouterState,
+    raw_token: &str,
+    from_cookie: bool,
+) -> Result<RefreshedTokens, RefreshError> {
+    let payload = if from_cookie {
+        state.jwt_service.verify_refresh(raw_token)
+    } else {
+        state.jwt_service.verify(raw_token)
+    }
+    .map_err(|_| RefreshError::Unauthorized("Invalid or expired token"))?;
 
     let user = state
         .user_repo
@@ -791,31 +890,42 @@ async fn refresh_handler(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "refresh token user lookup failed");
-            ApiError::Internal("Authentication service unavailable".into())
+            RefreshError::Internal("Authentication service unavailable")
         })?
-        .ok_or_else(|| ApiError::Unauthorized("Invalid authentication subject".into()))?;
+        .ok_or(RefreshError::Unauthorized("Invalid authentication subject"))?;
 
-    if state.aionpro_mode && user.user_type != aionui_db::UserType::Aionpro {
-        return Err(user_context_required());
+    if state.aionpro_mode && user.user_type != UserType::Aionpro {
+        return Err(RefreshError::UserContextRequired);
     }
 
     if payload.session_generation != user.session_generation {
-        return Err(ApiError::Unauthorized("Invalid authentication session".into()));
+        return Err(RefreshError::Unauthorized("Invalid authentication session"));
     }
 
-    let new_token = state
+    let access = state
         .jwt_service
         .sign_with_session_generation(
             &user.id,
             user.username.as_deref().unwrap_or("external_user"),
             user.session_generation,
         )
-        .map_err(|e| ApiError::Internal(format!("Token signing error: {e}")))?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "refresh access-token signing failed");
+            RefreshError::Internal("Token signing error")
+        })?;
+    let refresh = state
+        .jwt_service
+        .sign_refresh(
+            &user.id,
+            user.username.as_deref().unwrap_or("external_user"),
+            user.session_generation,
+        )
+        .map_err(|e| {
+            tracing::error!(error = %e, "refresh token signing failed");
+            RefreshError::Internal("Token signing error")
+        })?;
 
-    Ok(Json(RefreshResponse {
-        success: true,
-        token: new_token,
-    }))
+    Ok(RefreshedTokens { access, refresh })
 }
 
 // ---------------------------------------------------------------------------
@@ -881,13 +991,22 @@ async fn qr_login_handler(
             user.session_generation,
         )
         .map_err(|e| ApiError::Internal(format!("Token signing error: {e}")))?;
+    let refresh_token = state
+        .jwt_service
+        .sign_refresh(
+            &user.id,
+            user.username.as_deref().unwrap_or("external_user"),
+            user.session_generation,
+        )
+        .map_err(|e| ApiError::Internal(format!("Token signing error: {e}")))?;
 
     // Update last login (best-effort)
     if let Err(e) = state.user_repo.update_last_login(&user.id).await {
         tracing::warn!("Failed to update last login for {}: {e}", user.id);
     }
 
-    let cookie = state.cookie_config.build_session_cookie(&token);
+    let session_cookie = state.cookie_config.build_session_cookie(&token);
+    let refresh_cookie = state.cookie_config.build_refresh_cookie(&refresh_token);
     let resp = LoginResponse::new(
         PublicUser {
             id: user.id,
@@ -896,7 +1015,14 @@ async fn qr_login_handler(
         token,
     );
 
-    Ok(([(header::SET_COOKIE, cookie)], Json(resp)).into_response())
+    Ok((
+        AppendHeaders([
+            (header::SET_COOKIE, session_cookie),
+            (header::SET_COOKIE, refresh_cookie),
+        ]),
+        Json(resp),
+    )
+        .into_response())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-auth/src/service.rs
+++ b/crates/aionui-auth/src/service.rs
@@ -42,7 +42,11 @@ pub struct AuthProvisionService {
 
 pub struct ExternalSessionExchange {
     pub response: EnsureExternalSessionResponse,
+    /// Short-lived access token (set as the session cookie).
     pub token: String,
+    /// Long-lived refresh token (set as the refresh cookie) used to renew the
+    /// access token without re-authenticating.
+    pub refresh_token: String,
 }
 
 impl AuthProvisionService {
@@ -127,6 +131,9 @@ impl AuthProvisionService {
         let token = self
             .jwt_service
             .sign_with_session_generation(&user.id, &username, user.session_generation)?;
+        let refresh_token = self
+            .jwt_service
+            .sign_refresh(&user.id, &username, user.session_generation)?;
         self.user_repo.update_last_login(&user.id).await?;
 
         Ok(ExternalSessionExchange {
@@ -135,6 +142,7 @@ impl AuthProvisionService {
                 session_generation: user.session_generation,
             },
             token,
+            refresh_token,
         })
     }
 

--- a/crates/aionui-auth/src/singleflight.rs
+++ b/crates/aionui-auth/src/singleflight.rs
@@ -1,0 +1,132 @@
+//! Refresh-storm protection: coalesce concurrent refreshes.
+//!
+//! When an access token expires, every in-flight request from the same client
+//! can fail near-simultaneously and trigger a burst of refresh calls carrying
+//! the *same* refresh token. Without coordination each call would hit the
+//! database, re-sign a token pair, and (because refresh is sliding) bump the
+//! session — a self-inflicted stampede on the hottest auth path.
+//!
+//! [`RefreshCoalescer`] collapses that burst: concurrent refreshes presenting
+//! the same refresh token share a single execution and all receive the same
+//! result. A different token runs independently.
+//!
+//! Design notes:
+//! - **Key = the full refresh token, not a hash.** A truncated/hashed key could
+//!   collide, and a collision here is a security defect: two *different* tokens
+//!   would be coalesced and one caller would receive the other's freshly minted
+//!   credentials. The in-flight map only holds entries for the brief window a
+//!   refresh is running, so the memory cost of full-string keys is negligible.
+//! - **Success and failure are both coalesced.** The cell stores the whole
+//!   `Result`, so a single execution's outcome — `Ok` or `Err` — is shared by
+//!   every caller that piled onto it. A refresh failing under a storm therefore
+//!   hits the backend once, not once per coalesced caller. (This is why the
+//!   error type is `Clone`: the shared outcome is cloned out to each caller.)
+//! - **Failure is not cached across bursts.** The in-flight entry is removed as
+//!   soon as the execution completes, so a later refresh with the same token
+//!   starts a fresh execution rather than inheriting a stale failure.
+//! - **No lock is held across the await.** The DashMap guard is dropped before
+//!   awaiting the refresh future, so shard locks never span suspension points.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::OnceCell;
+
+/// Freshly minted token pair produced by a coalesced refresh.
+///
+/// Internal to the crate: only the refresh route consumes it. The refresh token
+/// is deliberately not exposed beyond the auth crate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RefreshedTokens {
+    /// New short-lived access token.
+    pub(crate) access: String,
+    /// New long-lived refresh token (sliding).
+    pub(crate) refresh: String,
+}
+
+/// Why a coalesced refresh failed.
+///
+/// Crate-owned and `Clone` so a single failed execution can be shared by every
+/// caller that coalesced onto it — the whole point of failure-path singleflight.
+/// It carries only a static reason string (no HTTP status, no `ApiError`), which
+/// keeps this module free of any API-boundary coupling; the refresh route maps
+/// each variant to the appropriate `ApiError`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RefreshError {
+    /// Refresh token missing, invalid, expired, wrong type, or its session was
+    /// revoked. Maps to `401 Unauthorized`.
+    Unauthorized(&'static str),
+    /// aionpro mode but the authenticated subject is not an aionpro user.
+    UserContextRequired,
+    /// Backend failure — user lookup or token signing. Maps to `500`.
+    Internal(&'static str),
+}
+
+/// The shared outcome of one coalesced refresh execution: a freshly minted
+/// token pair, or the reason it failed. Stored whole in the in-flight cell so
+/// that success and failure alike are shared by every coalesced caller.
+type RefreshOutcome = Result<RefreshedTokens, RefreshError>;
+
+/// Coalesces concurrent refreshes that present the same refresh token into a
+/// single execution.
+///
+/// Cheap to clone (an `Arc` handle) and safe to share across the router state.
+#[derive(Clone, Default)]
+pub struct RefreshCoalescer {
+    /// Refresh token -> the shared cell holding that refresh's single result
+    /// (whether it succeeded or failed).
+    inflight: Arc<DashMap<String, Arc<OnceCell<RefreshOutcome>>>>,
+}
+
+impl RefreshCoalescer {
+    /// Create an empty coalescer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run `refresh` for `token`, coalescing with any concurrent call for the
+    /// same token.
+    ///
+    /// The first caller for a given token executes `refresh`; callers that
+    /// arrive while it is in flight await the *same* outcome — success or
+    /// failure — instead of running their own. The outcome is not cached beyond
+    /// the burst: the in-flight entry is dropped once the execution completes,
+    /// so a later call re-executes rather than inheriting a stale outcome.
+    pub(crate) async fn run<F, Fut>(&self, token: &str, refresh: F) -> Result<RefreshedTokens, RefreshError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<RefreshedTokens, RefreshError>>,
+    {
+        // Obtain (or create) the shared cell for this token. The DashMap guard
+        // is scoped to this block and dropped before the await below, so no
+        // shard lock is ever held across the refresh future.
+        let cell = {
+            let entry = self
+                .inflight
+                .entry(token.to_owned())
+                .or_insert_with(|| Arc::new(OnceCell::new()));
+            Arc::clone(&entry)
+        };
+
+        // `get_or_init` stores the whole `Result` as the cell value, so the
+        // first caller executes `refresh` exactly once and every coalesced
+        // caller clones out the same outcome — including the error case, which
+        // `get_or_try_init` would instead leave uninitialized, letting each
+        // waiter re-run the closure and defeating singleflight on failures.
+        let outcome = cell.get_or_init(refresh).await.clone();
+
+        // Drop our cell from the map so the token does not accumulate entries
+        // and the next burst re-executes instead of reusing this outcome.
+        // Guard with a pointer check: a later caller may have installed a fresh
+        // cell after ours completed, and that one must not be removed.
+        self.inflight
+            .remove_if(token, |_, existing| Arc::ptr_eq(existing, &cell));
+
+        outcome
+    }
+}
+
+#[cfg(test)]
+#[path = "singleflight_test.rs"]
+mod singleflight_test;

--- a/crates/aionui-auth/src/singleflight_test.rs
+++ b/crates/aionui-auth/src/singleflight_test.rs
@@ -1,0 +1,125 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::task::yield_now;
+
+use super::{RefreshCoalescer, RefreshError, RefreshedTokens};
+
+#[tokio::test]
+async fn coalesces_concurrent_refreshes_for_same_token() {
+    let coalescer = RefreshCoalescer::new();
+    let calls = AtomicUsize::new(0);
+
+    let make = || async {
+        coalescer
+            .run("same-token", || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                // Yield so sibling callers pile up on the in-flight cell before
+                // this one finishes initializing it.
+                yield_now().await;
+                Ok(RefreshedTokens {
+                    access: "access".into(),
+                    refresh: "refresh".into(),
+                })
+            })
+            .await
+    };
+
+    let (a, b, c, d) = tokio::join!(make(), make(), make(), make());
+    for out in [a, b, c, d] {
+        let tokens = out.unwrap();
+        assert_eq!(tokens.access, "access");
+        assert_eq!(tokens.refresh, "refresh");
+    }
+    // Four concurrent callers, exactly one execution.
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn concurrent_failures_are_coalesced_into_one_execution() {
+    // Regression guard for the failure path: `get_or_try_init` left the cell
+    // uninitialized on error, so concurrent waiters each re-ran the closure — a
+    // failure stampede that defeats singleflight exactly when the backend is
+    // already struggling. Storing the whole `Result` via `get_or_init` fixes it:
+    // one execution, shared by all.
+    let coalescer = RefreshCoalescer::new();
+    let calls = AtomicUsize::new(0);
+
+    let make = || async {
+        coalescer
+            .run("same-token", || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                yield_now().await;
+                Err::<RefreshedTokens, _>(RefreshError::Unauthorized("boom"))
+            })
+            .await
+    };
+
+    let (a, b, c, d) = tokio::join!(make(), make(), make(), make());
+    for out in [a, b, c, d] {
+        assert_eq!(out, Err(RefreshError::Unauthorized("boom")));
+    }
+    // All four coalesced onto a single failed execution.
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn distinct_tokens_run_independently() {
+    let coalescer = RefreshCoalescer::new();
+    let calls = AtomicUsize::new(0);
+
+    let run = |tok: &'static str| async {
+        coalescer
+            .run(tok, || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(RefreshedTokens {
+                    access: tok.into(),
+                    refresh: tok.into(),
+                })
+            })
+            .await
+    };
+
+    let (a, b) = tokio::join!(run("token-a"), run("token-b"));
+    assert_eq!(a.unwrap().access, "token-a");
+    assert_eq!(b.unwrap().access, "token-b");
+    // Different tokens must not be coalesced together.
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn failure_is_not_cached_across_bursts_and_can_retry() {
+    let coalescer = RefreshCoalescer::new();
+
+    let first = coalescer
+        .run("tok", || async { Err(RefreshError::Unauthorized("boom")) })
+        .await;
+    assert_eq!(first, Err(RefreshError::Unauthorized("boom")));
+
+    // The failed attempt must not poison later refreshes of the same token: a
+    // new burst re-executes from scratch.
+    let second = coalescer
+        .run("tok", || async {
+            Ok(RefreshedTokens {
+                access: "ok".into(),
+                refresh: "ok".into(),
+            })
+        })
+        .await;
+    assert_eq!(second.unwrap().access, "ok");
+}
+
+#[tokio::test]
+async fn inflight_map_is_empty_after_completion() {
+    let coalescer = RefreshCoalescer::new();
+    coalescer
+        .run("tok", || async {
+            Ok(RefreshedTokens {
+                access: "a".into(),
+                refresh: "r".into(),
+            })
+        })
+        .await
+        .unwrap();
+    // The cell is cleaned up once the refresh completes.
+    assert!(coalescer.inflight.is_empty());
+}

--- a/crates/aionui-auth/tests/route_tests.rs
+++ b/crates/aionui-auth/tests/route_tests.rs
@@ -13,8 +13,8 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use aionui_auth::{
-    AuthIdentityMode, AuthRouterState, CookieConfig, JwtService, QrTokenStore, SessionRevokedHook, auth_routes,
-    hash_password,
+    AuthIdentityMode, AuthRouterState, CookieConfig, JwtService, QrTokenStore, RefreshCoalescer, SessionRevokedHook,
+    auth_routes, hash_password,
 };
 use aionui_db::{IUserRepository, SqliteUserRepository, UserStatus, init_database_memory};
 
@@ -52,6 +52,7 @@ async fn test_app_with_options_and_hook(
 
     let state = AuthRouterState {
         jwt_service: jwt_service.clone(),
+        refresh_coalescer: RefreshCoalescer::new(),
         user_repo: user_repo.clone(),
         fs_adopter: None,
         cookie_config,
@@ -189,6 +190,44 @@ fn extract_session_token(resp: &axum::response::Response) -> Option<String> {
                 .and_then(|value| value.split(';').next())
                 .map(str::to_owned)
         })
+}
+
+fn extract_refresh_token(resp: &axum::response::Response) -> Option<String> {
+    resp.headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(|cookie| {
+            cookie
+                .split(',')
+                .find(|part| part.trim_start().starts_with("aionui-refresh="))
+                .and_then(|part| part.trim_start().strip_prefix("aionui-refresh="))
+                .and_then(|value| value.split(';').next())
+                .map(str::to_owned)
+        })
+}
+
+/// Return every raw `Set-Cookie` header value on the response.
+fn set_cookie_values(resp: &axum::response::Response) -> Vec<String> {
+    resp.headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// POST carrying a `Cookie` header, used to exercise the refresh-cookie path.
+/// The JSON body is intentionally empty: when the cookie is present the handler
+/// must not read the body at all.
+fn post_with_cookie(uri: &str, cookie: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("cookie", cookie)
+        .body(Body::from("{}"))
+        .unwrap()
 }
 
 /// Helper: login and return (token, user_id).
@@ -679,6 +718,159 @@ async fn refresh_rejects_local_user_token_in_aionpro_mode() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let json = body_json(resp).await;
     assert_eq!(json["code"], "USER_CONTEXT_REQUIRED");
+}
+
+#[tokio::test]
+async fn refresh_via_cookie_success() {
+    let (app, ctx) = test_app().await;
+    create_test_user(&ctx, "admin", "StrongP@ss1").await;
+    // Login issues both the access (session) and refresh cookies.
+    let login_resp = app
+        .clone()
+        .oneshot(json_post("/login", r#"{"username":"admin","password":"StrongP@ss1"}"#))
+        .await
+        .unwrap();
+    assert_eq!(login_resp.status(), StatusCode::OK);
+    let refresh_cookie = extract_refresh_token(&login_resp).expect("login should set a refresh cookie");
+
+    // Present ONLY the refresh cookie (no body token) to the refresh endpoint.
+    let req = post_with_cookie("/api/auth/refresh", &format!("aionui-refresh={refresh_cookie}"));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    // The minted token is a usable access token.
+    let new_access = json["token"].as_str().unwrap();
+    assert!(ctx.jwt_service.verify_access(new_access).is_ok());
+}
+
+#[tokio::test]
+async fn refresh_via_cookie_rotates_both_cookies() {
+    let (app, ctx) = test_app().await;
+    create_test_user(&ctx, "admin", "StrongP@ss1").await;
+    let login_resp = app
+        .clone()
+        .oneshot(json_post("/login", r#"{"username":"admin","password":"StrongP@ss1"}"#))
+        .await
+        .unwrap();
+    let refresh_cookie = extract_refresh_token(&login_resp).expect("login should set a refresh cookie");
+
+    let req = post_with_cookie("/api/auth/refresh", &format!("aionui-refresh={refresh_cookie}"));
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // A refresh rotates BOTH cookies (sliding refresh): a new access cookie and
+    // a new refresh cookie, the latter still HttpOnly and scoped to the refresh
+    // path so it is never sent on ordinary requests.
+    let cookies = set_cookie_values(&resp);
+    assert!(
+        cookies.iter().any(|c| c.starts_with("aionui-session=")),
+        "missing rotated session cookie: {cookies:?}"
+    );
+    let refresh_set = cookies
+        .iter()
+        .find(|c| c.starts_with("aionui-refresh="))
+        .unwrap_or_else(|| panic!("missing rotated refresh cookie: {cookies:?}"));
+    assert!(
+        refresh_set.contains("Path=/api/auth/refresh"),
+        "refresh cookie not path-scoped: {refresh_set}"
+    );
+    assert!(
+        refresh_set.contains("HttpOnly"),
+        "refresh cookie must be HttpOnly: {refresh_set}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_rejects_access_token_in_refresh_cookie() {
+    let (mut app, ctx) = test_app().await;
+    create_test_user(&ctx, "admin", "StrongP@ss1").await;
+    // The token login returns is an ACCESS token.
+    let (access, _) = login(&mut app, "admin", "StrongP@ss1").await;
+
+    // Presenting it via the refresh cookie must be rejected: only refresh tokens
+    // are accepted on the cookie path (verify_refresh), so a stolen access token
+    // cannot be replayed to mint a long-lived session.
+    let req = post_with_cookie("/api/auth/refresh", &format!("aionui-refresh={access}"));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(resp).await;
+    assert_eq!(json["code"], "UNAUTHORIZED");
+    // Sanity: the same token still verifies fine as an access token.
+    assert!(ctx.jwt_service.verify_access(&access).is_ok());
+}
+
+#[tokio::test]
+async fn refresh_rejects_invalid_refresh_cookie() {
+    let (app, _ctx) = test_app().await;
+
+    let req = post_with_cookie("/api/auth/refresh", "aionui-refresh=not.a.jwt");
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(resp).await;
+    assert_eq!(json["code"], "UNAUTHORIZED");
+}
+
+#[tokio::test]
+async fn refresh_after_session_revocation_fails() {
+    let (app, ctx) = test_app().await;
+    create_test_user(&ctx, "admin", "StrongP@ss1").await;
+    let login_resp = app
+        .clone()
+        .oneshot(json_post("/login", r#"{"username":"admin","password":"StrongP@ss1"}"#))
+        .await
+        .unwrap();
+    let refresh_cookie = extract_refresh_token(&login_resp).expect("login should set a refresh cookie");
+    let user_id = body_json(login_resp).await["user"]["id"].as_str().unwrap().to_owned();
+
+    // Revoke all sessions for the user (logout-everywhere / password change).
+    ctx.user_repo.increment_session_generation(&user_id).await.unwrap();
+
+    // The old refresh cookie now carries a stale session generation and must be
+    // rejected — revocation reaches refresh tokens too.
+    let req = post_with_cookie("/api/auth/refresh", &format!("aionui-refresh={refresh_cookie}"));
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(resp).await;
+    assert_eq!(json["code"], "UNAUTHORIZED");
+}
+
+#[tokio::test]
+async fn refresh_concurrent_same_cookie_all_succeed() {
+    let (app, ctx) = test_app().await;
+    create_test_user(&ctx, "admin", "StrongP@ss1").await;
+    let login_resp = app
+        .clone()
+        .oneshot(json_post("/login", r#"{"username":"admin","password":"StrongP@ss1"}"#))
+        .await
+        .unwrap();
+    let refresh_cookie = extract_refresh_token(&login_resp).expect("login should set a refresh cookie");
+    let cookie = format!("aionui-refresh={refresh_cookie}");
+
+    // Fire several concurrent refreshes with the SAME refresh cookie — the shape
+    // of a real access-token-expiry storm. The backend coalescer must let them
+    // all succeed; exactly-once execution is asserted in the singleflight unit
+    // tests.
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let app = app.clone();
+        let cookie = cookie.clone();
+        handles.push(tokio::spawn(async move {
+            app.oneshot(post_with_cookie("/api/auth/refresh", &cookie))
+                .await
+                .unwrap()
+        }));
+    }
+    for handle in handles {
+        let resp = handle.await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(ctx.jwt_service.verify_access(json["token"].as_str().unwrap()).is_ok());
+    }
 }
 
 // ===========================================================================

--- a/crates/aionui-common/src/constants.rs
+++ b/crates/aionui-common/src/constants.rs
@@ -34,6 +34,19 @@ pub const COOKIE_MAX_AGE_DAYS: u32 = 30;
 pub const CSRF_COOKIE_NAME: &str = "aionui-csrf-token";
 pub const CSRF_HEADER_NAME: &str = "x-csrf-token";
 
+/// Cookie carrying the refresh token.
+///
+/// Distinct from the access-token session cookie so the two credential roles
+/// never share a container.
+pub const REFRESH_COOKIE_NAME: &str = "aionui-refresh";
+/// Path the refresh cookie is scoped to. The browser attaches it only when
+/// calling the refresh endpoint, keeping the long-lived credential off every
+/// ordinary API/WebSocket request.
+pub const REFRESH_COOKIE_PATH: &str = "/api/auth/refresh";
+/// Refresh-token / refresh-cookie lifetime in days. This is the window in which
+/// a session can be renewed without re-authenticating.
+pub const REFRESH_COOKIE_MAX_AGE_DAYS: u32 = 30;
+
 // --- Server ---
 
 pub const DEFAULT_HOST: &str = "127.0.0.1";


### PR DESCRIPTION
## Background & goal

Root-cause groundwork for iOfficeAI/AionUi#4124: on the remote WebUI (phone browser) the session token expires and never refreshes, trapping the client in a 401/reconnect loop. This is **PR-1, the server-side foundation** of a phased dual-token refresh.

The access-token TTL intentionally **stays 30d** in this PR. Shortening it before the frontend can auto-refresh would turn "expires once" into "forced logout every few hours", so the shortening lands last (PR-3), after frontend/mobile consumption (PR-2) ships.

## Changes

- **Dual-token model**: short-lived access token + long-lived refresh token, distinguished by an explicit `token_type` JWT claim (stateless HS256). The refresh token rides an HttpOnly cookie scoped to the refresh endpoint (browser) or the request body (native clients).
- **Refresh endpoint**: reads the refresh token from the HttpOnly cookie first, falling back to the request body (native); every issue point now emits both access + refresh tokens; the JSON response returns the new access token **and** the rotated refresh token.
- **Refresh-storm singleflight**: concurrent refreshes presenting the *same* refresh token coalesce into a single execution.
  - Key = the full token string (a hash could collide, which here is a security defect: credential cross-contamination, not just a perf loss).
  - Success and failure both coalesce (the whole `Result` is stored via `get_or_init`), so a storming refresh hits the backend once, not once per caller.
  - Failure is not cached across bursts (retryable); no lock is held across the await.

## Review fixes (this round)

- The refresh JSON now returns the rotated `refresh_token`, so native clients can migrate to dual-token.
- The failure path is truly singleflight (`get_or_try_init` -> `get_or_init`): concurrent failures share one execution instead of re-running serially.
- New test modules extracted to `*_test.rs` per workspace rules.
- Internal errors are logged via `tracing::error` + a static reason string (no `format!` detail leak).

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --workspace -D warnings` clean.
- Workspace full test: **9225 passed, 0 failed**.
- New coverage: singleflight (5 tests, incl. a concurrent-failure-coalescing regression guard), refresh response carries both tokens, WS / session-generation auth cases.

## Out of scope (by design)

- Access-TTL shortening -> PR-3 (last, to avoid amplifying #4124).
- Frontend + mobile consumption of the refresh flow -> PR-2.