### PR TITLE
chore(cli-version): verify agy against 1.1.19

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
 pub const VERIFIED_CODEX_VERSION: &str = "0.149.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.14";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.19";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -468,6 +468,20 @@ mod tests {
         assert_eq!(parse_version("2.1.220 (Claude Code)"), Some(vec![2, 1, 220]));
         assert_eq!(parse_version("codex-cli 0.144.6"), Some(vec![0, 144, 6]));
         assert_eq!(parse_version("1.1.10"), Some(vec![1, 1, 10]));
+    }
+
+    #[test]
+    fn the_verified_agy_release_says_nothing() {
+        // The literal the other two CLIs already pin, which agy was missing: a
+        // user on exactly the verified release is told nothing, and a bump that
+        // lands without re-verifying against that exact binary breaks here.
+        assert_eq!(classify("1.1.19", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.19", VERIFIED_AGY_VERSION).is_none());
+
+        // agy prints a bare version, so the older/newer paths are worth pinning
+        // on that exact shape rather than only on a decorated one.
+        assert_eq!(classify("1.1.18", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.20", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.14 to 1.1.19. All three gates clear, and gate C is runnable again after three runs blocked on it.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 175.68s |
| C — release notes | **CLEAR** — three REVIEW items, each resolved in the record |

## Gate C was blocked by a frozen web page, and did not need it

`https://antigravity.google/changelog` stops at **1.1.17 (August 20)** while the updater has since shipped 1.1.18 and 1.1.19. It is not lagging by a release — it is frozen. Byte-identical across three fetches spanning ~35 hours (same md5, same 355,577 bytes, 08-22 through 08-24). That had blocked this bump on three consecutive nightly runs.

**agy ships its own release notes.** `agy --help` lists a `changelog` subcommand we had never used, and `agy changelog` prints structured notes for every release — including the two the website is missing. It is a first-party source under `AGENTS.md`, and unlike the web page it cannot lag the binary under test, because it ships with it. Captured verbatim in the record as `changelog-from-cli.txt`.

## The three REVIEW items, and the limits of each resolution

- **Print mode now exits non-zero when the agent state stream drops** (1.1.18) — previously a failed turn reported as a clean empty success. Gate B 7/7 proves the happy path is unaffected. *Not exercised:* the suite never drops that stream, so the new error exit is unverified.
- **A valueless prompt flag is now a hard error** (1.1.18) — an argv shape that used to be tolerated. `build_argv` pushes the prompt immediately after `-p` (`antigravity/argv.rs:68-69`) and appends no trailing positional, so it never produces the offending shape; gate B confirms 1.1.19 accepts our argv as built.
- **1.1.17 consolidated the tool/hook/prompt execution path** — vague, and on three surfaces we depend on. Gate B drives tools, an MCP tool call and prompts, 7/7. *Not exercised:* the PreToolUse permission bridge is a known gate B blind spot, so the "hook" third is uncovered.

No flag was removed or renamed, and that is checked rather than inferred: `--help` and `models --help` are byte-identical between 1.1.18 and 1.1.19.

## The candidate is proven from the suite log

```
cli=agy version=1.1.19     # the only version the run ever reports
```

agy self-updates in place and keeps no old binary, so 1.1.19 was pulled from the updater manifest and **sha512-verified before being executed** (`54b6b0e2…`), then run through a PATH shim. The machine’s own agy stayed on 1.1.18.

## Tests

Adds the literal verified-release assertion agy was missing while claude and codex both had it, so a bump that forgets to re-verify breaks the test instead of shipping. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

## Follow-up, not included here

agy 1.1.15 claims to have fixed the stream-json non-ASCII corruption that #888 works around (`conn.rs:101-122`). If true, that mitigation is now inert rather than wrong. **Not verified this run** — confirming it needs a fresh capture against 1.1.19, and retiring the workaround is a source change that belongs in its own PR.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.19/`

Constants, one test, and the record — no source change.