### PR TITLE
fix(claude): apply model selection in-band so it matches the claude CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1651,11 +1651,58 @@ fn spec_mode_model(
     // through unchanged. Runs BEFORE the codex sandbox/approval derivation downstream
     // (which matches both the alias and the native id, so ordering is safe).
     let mode = resolved_session_mode(config, session_snapshot, metadata);
-    let model = session_snapshot
-        .and_then(|s| s.current_model_id.as_ref().map(|m| m.as_str().to_owned()))
-        .or_else(|| config.current_model_id.clone())
-        .filter(|s| !s.is_empty());
+    // Same drop-if-not-in-catalog discipline the mode path applies: a persisted
+    // selection outlives the catalog it came from, and no backend validates a model id
+    // at spawn — claude in particular ACCEPTS a bogus id and only fails once the user
+    // sends a message (LIVE-PROBED 2.1.231: both `--model <bogus>` and
+    // `set_model{<bogus>}` echo the id into `system.init.model`, then the turn dies with
+    // `result{is_error:true}`). Dropping it here turns that into a silent fall back to
+    // the agent's default, which is the difference between "my old pick quietly stopped
+    // applying" and "every message errors".
+    let model = clear_stale_model(
+        metadata,
+        session_snapshot
+            .and_then(|s| s.current_model_id.as_ref().map(|m| m.as_str().to_owned()))
+            .or_else(|| config.current_model_id.clone())
+            .filter(|s| !s.is_empty()),
+        conversation_id,
+    );
     (spec, mode, model)
+}
+
+/// Drop a model selection the agent's advertised catalog does not contain.
+///
+/// Pass-through when the catalog is absent or empty — that is the first-ever open of an
+/// agent (nothing handshaked yet), NOT evidence that the selection is invalid. Only a
+/// non-empty catalog that lacks the id is proof, and the id can legitimately go stale:
+/// the concrete rows depend on the user's `ANTHROPIC_DEFAULT_*` / provider env and on
+/// the CLI version, so an id stored months ago may simply no longer exist.
+fn clear_stale_model(
+    metadata: &aionui_api_types::AgentMetadata,
+    model: Option<String>,
+    conversation_id: &str,
+) -> Option<String> {
+    use crate::manager::acp::config_option_catalog::extract_models_from_value;
+    let model = model?;
+    let Some(catalog) = metadata
+        .handshake
+        .available_models
+        .as_ref()
+        .and_then(extract_models_from_value)
+    else {
+        return Some(model);
+    };
+    if catalog.available_models.is_empty() || catalog.available_models.iter().any(|entry| entry.model_id == model) {
+        return Some(model);
+    }
+    tracing::warn!(
+        conversation_id,
+        agent_id = %metadata.id,
+        requested_model = %model,
+        "persisted model selection is absent from the agent's catalog — falling back to \
+         the agent default for this session"
+    );
+    None
 }
 
 /// Build a claude/codex `SessionAgentTask` (the session-model port's `IAgentTask`)
@@ -5006,6 +5053,71 @@ mod build_mapping_tests {
         ));
         assert_eq!(mode.as_deref(), Some("plan"));
         assert_eq!(model.as_deref(), Some("claude-x"));
+    }
+
+    // A catalog row carrying the persisted `{available_models:[{id,label}]}` shape the
+    // handshake write-back stores, for the stale-selection guard.
+    fn metadata_with_models(ids: &[&str]) -> aionui_api_types::AgentMetadata {
+        let mut md = test_metadata(Some("claude"), None);
+        md.handshake.available_models = Some(serde_json::json!({
+            "available_models": ids.iter().map(|id| serde_json::json!({"id": id, "label": id})).collect::<Vec<_>>(),
+            "current_model_id": ids.first().copied().unwrap_or_default(),
+        }));
+        md
+    }
+
+    /// A persisted selection the agent no longer advertises is DROPPED at build time,
+    /// so the session falls back to the agent default instead of failing on the user's
+    /// first message. No backend validates a model id at spawn — claude echoes a bogus
+    /// one into `system.init.model` and only dies at turn time (LIVE-PROBED 2.1.231 for
+    /// both `--model` and in-band `set_model`) — so this is the only guard that runs
+    /// before the user is affected.
+    #[test]
+    fn stale_model_selection_is_dropped_before_it_reaches_the_backend() {
+        let cfg = AcpBuildExtra {
+            // A concrete id that only existed under a previous ANTHROPIC_DEFAULT_* /
+            // provider env or CLI version.
+            current_model_id: Some("claude-opus-4-8[1m]".into()),
+            ..Default::default()
+        };
+        let md = metadata_with_models(&["default", "sonnet", "opus", "haiku"]);
+        let (_spec, _mode, model) = spec_mode_model("conv_stale", None, &cfg, None, &md);
+        assert_eq!(model, None, "an id absent from the catalog must not be sent");
+
+        // A selection the catalog DOES advertise survives untouched.
+        let live = AcpBuildExtra {
+            current_model_id: Some("haiku".into()),
+            ..Default::default()
+        };
+        let (_spec, _mode, model) = spec_mode_model("conv_live", None, &live, None, &md);
+        assert_eq!(model.as_deref(), Some("haiku"));
+
+        // `default` is a real catalog row, so it survives here; suppressing it is the
+        // claude backend's job (`desired_model_from_config`), not this guard's.
+        let default_row = AcpBuildExtra {
+            current_model_id: Some("default".into()),
+            ..Default::default()
+        };
+        let (_spec, _mode, model) = spec_mode_model("conv_default", None, &default_row, None, &md);
+        assert_eq!(model.as_deref(), Some("default"));
+    }
+
+    /// No catalog (first-ever open, nothing handshaked) is NOT evidence the selection is
+    /// invalid — dropping it there would break the very first session of every agent,
+    /// including codex/ACP backends that share this path.
+    #[test]
+    fn model_selection_passes_through_when_no_catalog_is_known_yet() {
+        let cfg = AcpBuildExtra {
+            current_model_id: Some("gpt-5.6-terra".into()),
+            ..Default::default()
+        };
+        // handshake.available_models = None
+        let (_spec, _mode, model) = spec_mode_model("conv_a", None, &cfg, None, &test_metadata(Some("codex"), None));
+        assert_eq!(model.as_deref(), Some("gpt-5.6-terra"), "absent catalog ⇒ pass through");
+
+        // An EMPTY catalog is equally uninformative.
+        let (_spec, _mode, model) = spec_mode_model("conv_b", None, &cfg, None, &metadata_with_models(&[]));
+        assert_eq!(model.as_deref(), Some("gpt-5.6-terra"), "empty catalog ⇒ pass through");
     }
 
     /// Fork-spec quadrant matrix (sid x fork): a bound sid ALWAYS resumes (the

--- a/crates/aionui-session/Cargo.toml
+++ b/crates/aionui-session/Cargo.toml
@@ -37,7 +37,10 @@ test-support = []
 aionui-session = { path = ".", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }
 proptest.workspace = true
-# live_cli_e2e.rs (#[ignore] LIVE tests): a tempdir-backed FileRegistryStore for
+# live_claude_model.rs (#[ignore] LIVE tests): a tempdir-backed FileRegistryStore for
 # constructing a production RealSpawner without touching the real data dir.
 # Workspace-pinned; dev-only (never shipped). (uuid is a normal dep above.)
 tempfile.workspace = true
+# live_claude_model.rs observes the reconcile log line (the only place a session's
+# CONCRETE model is visible) via a capturing Layer. Dev-only.
+tracing-subscriber.workspace = true

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -246,24 +246,24 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
     // NO `--model` FLAG — the selection is applied in-band via
     // `control_request{set_model}` after the spawn (see `apply_desired_model`).
     //
-    // LIVE-PROBED 2.1.231, why the flag cannot carry our selection:
-    //   1. `--model default` is NOT a no-op. Our picker's "Default" row has the wire
-    //      value `default`, and passing it OVERRIDES the user's own `ANTHROPIC_MODEL`
-    //      (`~/.claude/settings.json` env block): with `ANTHROPIC_MODEL=claude-opus-5[1m]`,
-    //      `system.init.model` is `claude-opus-5[1m]` with NO flag but
-    //      `claude-opus-4-8[1m]` with `--model default`. So the flag silently ran a
-    //      DIFFERENT model than the CLI would for the same config.
-    //   2. The `initialize` catalog (`response.models[]`) is a FUNCTION of this flag —
-    //      no flag → 6 rows (incl. the `ANTHROPIC_MODEL` row, e.g. "Opus 5 (1M context)"),
-    //      `--model default` → 6 rows but that row becomes "Opus 4.8 (1M context)",
-    //      `--model opus` → 5 rows (the row is dropped). Since the catalog is persisted
-    //      per-AGENT (last write wins), a session spawned with an alias ERASED a model
-    //      the picker was offering everyone else. Spawning flagless makes the catalog
-    //      constant AND identical to what `/model` shows in the terminal.
-    // `set_model` applies before the first turn (init reports the switched model) and
-    // is re-applied on every `--resume` respawn, because claude does NOT restore a
-    // session's model on resume (LIVE-PROBED: resume without the flag reports the
-    // default model, not the one the session was set to).
+    // The flag would carry the model itself just fine. It is disqualified because it ALSO
+    // reshapes the catalog we persist for the picker (LIVE-PROBED 2.1.231): the
+    // `initialize` reply's `models[]` is a FUNCTION of this flag —
+    //   no flag          → 6 rows, the last being the `ANTHROPIC_MODEL` one
+    //                      (e.g. `claude-opus-5[1m]` / "Opus 5 (1M context)")
+    //   --model default  → 6 rows, but that last row becomes "Opus 4.8 (1M context)"
+    //   --model opus     → 5 rows, the last row is gone entirely
+    // The catalog is persisted per-AGENT (last write wins), so a session spawned on an
+    // alias ERASED a model the picker was offering every other conversation, and the
+    // `ANTHROPIC_MODEL` row was unreachable no matter what the user picked. Spawning
+    // flagless makes the catalog constant AND identical to what `/model` lists in the
+    // terminal; `set_model` then carries the selection without touching it (probed: the
+    // catalog is still those 6 rows after a set_model).
+    //
+    // `set_model` applies before the first turn (init reports the switched model) and is
+    // re-applied on every `--resume` respawn, because claude does NOT restore a session's
+    // model on resume (LIVE-PROBED: resume with neither flag nor set_model reports the
+    // config-resolved model, not the one the session had been switched to).
 
     args
 }
@@ -497,9 +497,8 @@ pub struct ClaudeSessionBackend {
     /// One-shot first-turn title generation (spec 2026-08-04). Shared with the
     /// reader via `reader_state`; `dispatch(Send)` records the first prompt text.
     title_gen: Arc<TitleGenState>,
-    /// The model row id to ask claude for via in-band `set_model`, `None` for the
-    /// "Default" row (expressed by sending nothing — see `build_claude_init_args` for
-    /// why the `--model` flag cannot express our selection). Applied after the
+    /// The model row id to ask claude for via in-band `set_model`, `None` when the
+    /// session carries NO selection (see `desired_model_from_config`). Applied after the
     /// initialize request at open, RE-APPLIED after every F-4 wake (claude does NOT
     /// restore a session's model on `--resume`, LIVE-PROBED 2.1.231), and rewritten by
     /// `dispatch(SetModel)` so a wake re-applies the user's CURRENT pick. Shared with
@@ -507,24 +506,27 @@ pub struct ClaudeSessionBackend {
     desired_model: Arc<std::sync::Mutex<Option<String>>>,
 }
 
-/// The `set_model` target for a config selection, or `None` when nothing should be
-/// sent.
+/// The `set_model` target for a config selection, or `None` when nothing should be sent.
 ///
-/// Our model picker's first row is claude's own `default` row, meaning "use whatever
-/// the user's config resolves to". That intent is expressed by sending NO model at
-/// all: passing the literal `default` is NOT a no-op — it OVERRIDES the user's
-/// `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231; see `build_claude_init_args`), which
-/// silently ran a different model than the terminal CLI would for the same config.
+/// EVERY row of claude's catalog is sent verbatim, `default` included. The two states are
+/// distinguished by PRESENCE, not by value:
+///
+/// - **no selection** (`None`/empty) → send nothing → claude resolves the model from the
+///   user's own config (`ANTHROPIC_MODEL`, else the account default), which is exactly
+///   what the terminal CLI does on startup.
+/// - **`default`** → send it → claude runs the ACCOUNT default, overriding
+///   `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231: with `ANTHROPIC_MODEL=claude-opus-5[1m]`,
+///   `set_model{default}` and `--model default` both report `claude-opus-4-8[1m]` in
+///   `system.init.model`). That IS the semantic of the CLI's own `Default` row — its
+///   description reads "Use the default model (currently Opus 4.8 (1M context))" — so
+///   suppressing it made the picker contradict itself: the row promised 4.8 and the
+///   session ran opus-5.
+///
+/// Do NOT re-add a `default` special case here. The distinction belongs upstream: a
+/// session with no user pick must carry no model at all, not the literal `default`.
 fn desired_model_from_config(model: Option<&str>) -> Option<String> {
-    model
-        .map(str::trim)
-        .filter(|s| !s.is_empty() && *s != CLAUDE_DEFAULT_MODEL_ROW)
-        .map(str::to_owned)
+    model.map(str::trim).filter(|s| !s.is_empty()).map(str::to_owned)
 }
-
-/// claude's own wire id for the "use my configured default" row of `models[]`
-/// (LIVE-PROBED 2.1.231: `{"value":"default","displayName":"Default"}`).
-const CLAUDE_DEFAULT_MODEL_ROW: &str = "default";
 
 /// First-turn session-title generation state (spec 2026-08-04, retry semantics
 /// 2026-08-13).
@@ -1407,9 +1409,10 @@ impl ClaudeSessionBackend {
     /// Apply the session's model selection in-band, the replacement for the removed
     /// `--model` spawn flag (see `build_claude_init_args` for why the flag had to go).
     ///
-    /// No-op for the "Default" row (`desired_model` is `None`) — that intent IS "send
-    /// nothing", so claude resolves the model from the user's own config exactly as the
-    /// terminal CLI does.
+    /// No-op when the session carries NO selection (`desired_model` is `None`) — that
+    /// intent IS "send nothing", so claude resolves the model from the user's own config
+    /// exactly as the terminal CLI does on startup. A session that DID pick the `default`
+    /// row sends it like any other row (see `desired_model_from_config`).
     ///
     /// Must be called on EVERY process run — open AND each F-4 wake — because
     /// `--resume` does NOT restore the model a session was set to (LIVE-PROBED 2.1.231:
@@ -2193,11 +2196,13 @@ fn register_or_clear_pending(
 /// `system.init.model` reports the RESOLVED concrete id (selection `haiku` → init
 /// `claude-haiku-4-5`).
 ///
-/// A run with NO selection sent is reported but never compared. That is load-bearing,
-/// not an optimization: the `default` row's own `resolvedModel` does NOT account for
-/// `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231 — the row reports
-/// `resolvedModel: claude-opus-4-8[1m]` while the process runs `claude-opus-5[1m]` from
-/// the env), so comparing against it would fire a false mismatch on every such session.
+/// A run with NO selection sent is reported but never compared, because there is no
+/// catalog row that predicts it: with `ANTHROPIC_MODEL=claude-opus-5[1m]` such a run
+/// reports `claude-opus-5[1m]`, while the closest-looking row (`default`) carries
+/// `resolvedModel: claude-opus-4-8[1m]` — that row describes what happens when `default`
+/// is REQUESTED (it overrides the env), not what an unrequested run resolves to
+/// (LIVE-PROBED 2.1.231, both directions). Comparing the two would fire a false mismatch
+/// on every session that made no pick.
 fn reconcile_init_model(
     frame: &serde_json::Value,
     desired_model: &Arc<std::sync::Mutex<Option<String>>>,
@@ -5614,19 +5619,27 @@ mod tests {
         );
     }
 
-    /// The "Default" picker row means "send NO model" — because `--model default` (and,
-    /// by the same wire value, `set_model{default}`) OVERRIDES the user's own
-    /// `ANTHROPIC_MODEL` instead of deferring to it (LIVE-PROBED 2.1.231: with
-    /// `ANTHROPIC_MODEL=claude-opus-5[1m]`, `system.init.model` is `claude-opus-5[1m]`
-    /// with no flag but `claude-opus-4-8[1m]` with `--model default`).
+    /// "no selection" and "the `default` row" are distinguished by PRESENCE, never by
+    /// value. `default` is a REAL choice — claude runs the account default for it,
+    /// overriding `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231), which is exactly what the CLI's
+    /// own `Default` row promises ("Use the default model (currently ...)"). Suppressing
+    /// it made the picker contradict itself, so it must travel like any other row.
     #[test]
-    fn desired_model_from_config_suppresses_only_the_default_row() {
-        assert_eq!(desired_model_from_config(Some("default")), None, "the sentinel row");
-        assert_eq!(desired_model_from_config(Some("  default  ")), None, "trimmed sentinel");
+    fn desired_model_from_config_sends_every_row_and_only_drops_absence() {
         assert_eq!(desired_model_from_config(None), None, "no selection at all");
         assert_eq!(desired_model_from_config(Some("")), None, "empty");
         assert_eq!(desired_model_from_config(Some("   ")), None, "whitespace only");
-        // Everything else travels in-band verbatim — aliases AND concrete ids.
+        // Every catalog row travels in-band verbatim — `default`, aliases, concrete ids.
+        assert_eq!(
+            desired_model_from_config(Some("default")),
+            Some("default".to_string()),
+            "the `default` row is a real pick, NOT a synonym for 'no selection'"
+        );
+        assert_eq!(
+            desired_model_from_config(Some("  default  ")),
+            Some("default".to_string()),
+            "trimmed, not dropped"
+        );
         assert_eq!(desired_model_from_config(Some("opus")), Some("opus".to_string()));
         assert_eq!(desired_model_from_config(Some("haiku")), Some("haiku".to_string()));
         assert_eq!(
@@ -5674,15 +5687,15 @@ mod tests {
         seen
     }
 
-    /// The Default row writes NOTHING: sending `set_model{default}` would override the
-    /// user's `ANTHROPIC_MODEL`, which is exactly the bug this path exists to avoid.
+    /// A session with NO selection writes nothing, so claude resolves the model from the
+    /// user's own config (`ANTHROPIC_MODEL` / account default) like the terminal CLI.
     #[tokio::test]
-    async fn apply_desired_model_writes_nothing_for_the_default_row() {
+    async fn apply_desired_model_writes_nothing_without_a_selection() {
         let fake = FakeAgentIo::never_exits(Vec::new());
         let captured = fake.captured_stdin();
         let backend = ClaudeSessionBackend::build_with_io("s", Box::new(fake)).await;
 
-        *backend.desired_model.lock().unwrap() = desired_model_from_config(Some("default"));
+        *backend.desired_model.lock().unwrap() = desired_model_from_config(None);
         backend.apply_desired_model().await;
 
         // Absence needs a barrier, not a sleep: write a prompt AFTER the (expected)
@@ -5702,7 +5715,7 @@ mod tests {
         );
         assert!(
             !written.contains("set_model"),
-            "the Default row must not send any model, got: {written}"
+            "a session with no selection must not send any model, got: {written}"
         );
     }
 
@@ -5724,8 +5737,9 @@ mod tests {
             "a wake must re-apply the user's CURRENT pick"
         );
 
-        // Switching back to Default clears it, so a woken process resolves the model
-        // from the user's own config again rather than re-pinning the old pick.
+        // Switching to the `default` row is a REAL pick (claude runs the account default
+        // for it), so the slot keeps it and a wake re-applies it — clearing the slot here
+        // would silently turn "I want the account default" back into "follow my env".
         backend
             .dispatch(Command::SetModel {
                 model: "default".into(),
@@ -5734,8 +5748,8 @@ mod tests {
             .expect("SetModel(default) accepted");
         assert_eq!(
             backend.desired_model.lock().unwrap().clone(),
-            None,
-            "Default must clear the slot, not pin the literal sentinel"
+            Some("default".to_string()),
+            "the `default` row must be re-applied on wake like any other pick"
         );
     }
 
@@ -5807,11 +5821,19 @@ mod tests {
                 running: "claude-opus-5[1m]".into()
             }
         );
-        // No selection sent (the Default row): REPORTED but never compared. Comparing
-        // would misfire — the `default` row's resolvedModel ignores ANTHROPIC_MODEL, so
-        // such a session legitimately runs `claude-opus-5[1m]` while the row says
-        // `claude-opus-4-8[1m]` (LIVE-PROBED 2.1.231). Reporting it is the ONLY trace of
-        // what the most common case actually ran.
+        // The `default` row IS checked, because we send it and claude then honours it:
+        // its resolvedModel is the account default and that is what init reports.
+        assert_eq!(
+            check_init_model(&init("claude-opus-4-8[1m]"), Some("default"), &resolved),
+            InitModelCheck::Applied {
+                requested: "default".into(),
+                running: "claude-opus-4-8[1m]".into()
+            }
+        );
+        // NO selection sent: REPORTED but never compared. No row predicts this run — the
+        // `default` row describes what happens when `default` is REQUESTED (it overrides
+        // ANTHROPIC_MODEL), so comparing an unrequested run against it would misfire
+        // (LIVE-PROBED 2.1.231). Reporting it is the ONLY trace of what such a session ran.
         assert_eq!(
             check_init_model(&init("claude-opus-5[1m]"), None, &resolved),
             InitModelCheck::ResolvedByCli {

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -144,8 +144,9 @@ fn prepend_args(head: &[String], tail: &[String]) -> Vec<String> {
 ///   ("System prompt to use for the session" vs "Append a system prompt to the default
 ///   system prompt", verified: `claude --help`, 2.1.234), silently stripping the
 ///   harness's own guidance — the same defect class as codex `baseInstructions`.
-/// - `model` → `--model`; `mode` → `--permission-mode` (claude has no in-band
-///   switch at spawn; a UI switch persists + evicts so the rebuild re-applies here).
+/// - `mode` → `--permission-mode` (claude has no in-band switch at spawn; a UI switch
+///   persists + evicts so the rebuild re-applies here). `model` is deliberately NOT
+///   mapped to `--model` — see the comment at the end of this fn.
 ///
 /// claude's `--mcp-config` uses a MAP shape `{"mcpServers":{"<name>":{…}}}` (NOT the
 /// ACP array), so this builds its own JSON rather than reusing `acp_conn`'s array
@@ -242,10 +243,27 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
     // show a single-question permission card — removing the flag is the claude
     // half of P0; the adapter routes the tool to `Ask`, never to `Permission`.
 
-    if let Some(model) = config.model.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        args.push("--model".to_string());
-        args.push(model.to_string());
-    }
+    // NO `--model` FLAG — the selection is applied in-band via
+    // `control_request{set_model}` after the spawn (see `apply_desired_model`).
+    //
+    // LIVE-PROBED 2.1.231, why the flag cannot carry our selection:
+    //   1. `--model default` is NOT a no-op. Our picker's "Default" row has the wire
+    //      value `default`, and passing it OVERRIDES the user's own `ANTHROPIC_MODEL`
+    //      (`~/.claude/settings.json` env block): with `ANTHROPIC_MODEL=claude-opus-5[1m]`,
+    //      `system.init.model` is `claude-opus-5[1m]` with NO flag but
+    //      `claude-opus-4-8[1m]` with `--model default`. So the flag silently ran a
+    //      DIFFERENT model than the CLI would for the same config.
+    //   2. The `initialize` catalog (`response.models[]`) is a FUNCTION of this flag —
+    //      no flag → 6 rows (incl. the `ANTHROPIC_MODEL` row, e.g. "Opus 5 (1M context)"),
+    //      `--model default` → 6 rows but that row becomes "Opus 4.8 (1M context)",
+    //      `--model opus` → 5 rows (the row is dropped). Since the catalog is persisted
+    //      per-AGENT (last write wins), a session spawned with an alias ERASED a model
+    //      the picker was offering everyone else. Spawning flagless makes the catalog
+    //      constant AND identical to what `/model` shows in the terminal.
+    // `set_model` applies before the first turn (init reports the switched model) and
+    // is re-applied on every `--resume` respawn, because claude does NOT restore a
+    // session's model on resume (LIVE-PROBED: resume without the flag reports the
+    // default model, not the one the session was set to).
 
     args
 }
@@ -350,6 +368,10 @@ impl BackendConnection for ClaudeConnection {
         // first `capabilities()` read; a late response is merged on the next read
         // (same late-discovery contract as codex `model/list`).
         backend.request_initialize().await;
+        // Apply the model selection in-band (the removed `--model` flag's replacement).
+        // Ordered AFTER initialize purely for log readability — both are written before
+        // any prompt, which is all the ordering the CLI requires.
+        backend.apply_desired_model().await;
         // Report a claude whose version differs from the release AionUi
         // verified. claude runs from the user's own install (nothing is
         // bundled), so this is the same situation agy has always been in.
@@ -475,7 +497,34 @@ pub struct ClaudeSessionBackend {
     /// One-shot first-turn title generation (spec 2026-08-04). Shared with the
     /// reader via `reader_state`; `dispatch(Send)` records the first prompt text.
     title_gen: Arc<TitleGenState>,
+    /// The model row id to ask claude for via in-band `set_model`, `None` for the
+    /// "Default" row (expressed by sending nothing — see `build_claude_init_args` for
+    /// why the `--model` flag cannot express our selection). Applied after the
+    /// initialize request at open, RE-APPLIED after every F-4 wake (claude does NOT
+    /// restore a session's model on `--resume`, LIVE-PROBED 2.1.231), and rewritten by
+    /// `dispatch(SetModel)` so a wake re-applies the user's CURRENT pick. Shared with
+    /// the reader, which checks it against `system/init` (`reconcile_init_model`).
+    desired_model: Arc<std::sync::Mutex<Option<String>>>,
 }
+
+/// The `set_model` target for a config selection, or `None` when nothing should be
+/// sent.
+///
+/// Our model picker's first row is claude's own `default` row, meaning "use whatever
+/// the user's config resolves to". That intent is expressed by sending NO model at
+/// all: passing the literal `default` is NOT a no-op — it OVERRIDES the user's
+/// `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231; see `build_claude_init_args`), which
+/// silently ran a different model than the terminal CLI would for the same config.
+fn desired_model_from_config(model: Option<&str>) -> Option<String> {
+    model
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != CLAUDE_DEFAULT_MODEL_ROW)
+        .map(str::to_owned)
+}
+
+/// claude's own wire id for the "use my configured default" row of `models[]`
+/// (LIVE-PROBED 2.1.231: `{"value":"default","displayName":"Default"}`).
+const CLAUDE_DEFAULT_MODEL_ROW: &str = "default";
 
 /// First-turn session-title generation state (spec 2026-08-04, retry semantics
 /// 2026-08-13).
@@ -697,6 +746,16 @@ struct ClaudeWakeRecipe {
 struct DiscoveredCaps {
     models: Vec<crate::capability::ModelInfo>,
     slash_commands: Vec<crate::capability::SlashCommandInfo>,
+    /// Row id → the CONCRETE model that row resolves to, from the initialize
+    /// reply's `models[].resolvedModel` (LIVE-PROBED 2.1.231:
+    /// `{"value":"haiku","resolvedModel":"claude-haiku-4-5"}`).
+    ///
+    /// This is the ONLY basis for checking that an in-band `set_model` landed:
+    /// `system.init.model` reports the RESOLVED id, while our selection is the ROW
+    /// id, and no other field bridges the two (`displayName` is "Default" / "Fable"
+    /// for those rows). Kept private to this module — the reconcile is the only
+    /// consumer today, so it does not need to ride `ModelInfo` across the seam.
+    resolved_models: std::collections::HashMap<String, String>,
 }
 
 /// Session-cumulative cost ledger. claude's `result.total_cost_usd` is
@@ -755,6 +814,12 @@ struct ClaudeReaderState {
     /// reader overwrites it from `system/init` so a post-fork / post-rotation
     /// wake resumes the sid claude actually reported, never the stale spawn id.
     wake_session_slot: Arc<std::sync::Mutex<String>>,
+    /// The model row id we ask claude for via in-band `set_model`, or `None` for the
+    /// "Default" row (which is expressed by sending NOTHING — see
+    /// `build_claude_init_args`). Shared Arc with the backend, which re-applies it on
+    /// every wake and rewrites it on a user switch; the reader only reads it, to check
+    /// the applied model against `system/init` (`reconcile_init_model`).
+    desired_model: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 /// Spawn a claude stdout reader over `stdout`/`io` using the shared state. Used
@@ -799,6 +864,7 @@ fn start_claude_reader(
             state.cost_ledger,
             state.title_gen,
             state.wake_session_slot,
+            state.desired_model,
         )
         .await;
     })
@@ -879,6 +945,15 @@ impl ClaudeSessionBackend {
             last_raw: 0.0,
         }));
 
+        // The selection to apply in-band, `None` for "Default" (see
+        // `desired_model_from_config`). Shared with the reader (landed-check) and
+        // rewritten by dispatch(SetModel) so a later wake re-applies the CURRENT pick,
+        // not the open-time one — which the old `--model` arg could not do, since the
+        // wake recipe replays the spawn args verbatim.
+        let desired_model = Arc::new(std::sync::Mutex::new(desired_model_from_config(
+            config.model.as_deref(),
+        )));
+
         let reader_state = ClaudeReaderState {
             session_id: session_id.clone(),
             turn_gen: turn_gen.clone(),
@@ -893,6 +968,7 @@ impl ClaudeSessionBackend {
             cost_ledger,
             title_gen: title_gen.clone(),
             wake_session_slot: wake.claude_session_id.clone(),
+            desired_model: desired_model.clone(),
         };
         let reader = start_claude_reader(&reader_state, stdout, io.clone());
 
@@ -949,6 +1025,7 @@ impl ClaudeSessionBackend {
             current_mode_override,
             pending_set_config,
             title_gen,
+            desired_model,
         }
     }
 
@@ -991,6 +1068,11 @@ impl ClaudeSessionBackend {
         // writes to the woken process (the old stdin dropped with the old io).
         *self.stdin.lock().await = stdin;
         let reader = start_claude_reader(&self.reader_state, stdout, io.clone());
+        // Re-apply the model selection to the FRESH process: `--resume` does not carry
+        // it (LIVE-PROBED 2.1.231 — a resumed session reports the default model), and it
+        // is no longer in `wake.extra_args` either. Reads the shared slot, so a
+        // mid-session switch is what gets re-applied, not the open-time pick.
+        self.apply_desired_model().await;
         Ok(ProcHandle::new(reader, io))
     }
 
@@ -1322,6 +1404,45 @@ impl ClaudeSessionBackend {
         }
     }
 
+    /// Apply the session's model selection in-band, the replacement for the removed
+    /// `--model` spawn flag (see `build_claude_init_args` for why the flag had to go).
+    ///
+    /// No-op for the "Default" row (`desired_model` is `None`) — that intent IS "send
+    /// nothing", so claude resolves the model from the user's own config exactly as the
+    /// terminal CLI does.
+    ///
+    /// Must be called on EVERY process run — open AND each F-4 wake — because
+    /// `--resume` does NOT restore the model a session was set to (LIVE-PROBED 2.1.231:
+    /// a resume with no flag and no `set_model` reports the default model in
+    /// `system.init.model`, not the one the previous run had switched to).
+    ///
+    /// Written BEFORE the first prompt, which is what makes it take effect for turn 1:
+    /// claude processes it ahead of `system/init`, so the init frame already reports the
+    /// switched model (LIVE-PROBED 2.1.231) and there is no window where a turn runs on
+    /// the default model. Best-effort like `request_initialize` — a write failure leaves
+    /// the run on the default model, which `reconcile_init_model` then reports.
+    async fn apply_desired_model(&self) {
+        let Some(model) = self.desired_model.lock().unwrap_or_else(|e| e.into_inner()).clone() else {
+            return;
+        };
+        tracing::info!(
+            session_id = %self.session_id,
+            requested_model = %model,
+            "claude applying model selection via in-band set_model"
+        );
+        if let Err(e) = self
+            .write_or_queue_control(serde_json::json!({ "subtype": "set_model", "model": model }))
+            .await
+        {
+            tracing::warn!(
+                session_id = %self.session_id,
+                requested_model = %model,
+                error = %e,
+                "claude set_model write failed — the run stays on the default model"
+            );
+        }
+    }
+
     /// Frame + flush one control_request over the retained stdin (same NDJSON path
     /// as a control_response). The CLI's success control_response is observed by the
     /// reader, not awaited here (the switch applies to the next turn).
@@ -1528,6 +1649,7 @@ async fn reader_task(
     cost_ledger: Arc<std::sync::Mutex<CostLedger>>,
     title_gen: Arc<TitleGenState>,
     wake_session_slot: Arc<std::sync::Mutex<String>>,
+    desired_model: Arc<std::sync::Mutex<Option<String>>>,
 ) {
     use std::sync::atomic::Ordering;
     use tokio::io::AsyncReadExt;
@@ -1600,6 +1722,12 @@ async fn reader_task(
                     cur_gen,
                     &wake_session_slot,
                 );
+                // Confirm the in-band `set_model` we sent at spawn/wake landed. The
+                // init frame is the ONLY signal for this (a `set_model` sent mid-turn
+                // has no confirmation channel at all — see dispatch(SetModel)), and it
+                // arrives with the first turn of every process run, so a wake's
+                // re-apply is covered too.
+                reconcile_init_model(v, &desired_model, &discovered_caps, &session_id);
                 // #98/#101: sniff the `control_request{initialize}` RESPONSE for the
                 // selectable model list + slash commands (claude's only catalog
                 // channel — the data init frame above carries neither). Fills
@@ -2043,6 +2171,117 @@ fn register_or_clear_pending(
     }
 }
 
+/// Check that the in-band `set_model` we sent at spawn/wake actually took effect.
+///
+/// claude does NOT validate a model id: neither `--model <bogus>` nor
+/// `set_model{<bogus>}` fails at spawn — the id is echoed back in `system.init.model`
+/// verbatim and the turn only dies with `result{is_error:true}` once the user sends a
+/// message (LIVE-PROBED 2.1.231 for BOTH paths, so this is pre-existing behaviour, not
+/// a cost of going in-band). The primary guard is upstream: the app layer drops a
+/// selection that is not in the catalog before it is ever sent. This is the backstop
+/// for what upstream cannot see — a row that exists but resolves elsewhere, or a
+/// `set_model` claude silently ignored — so a "the model I picked is not the one
+/// running" report is diagnosable from an `info`-level production log.
+///
+/// Compares against `resolved_models[selection]`, NOT the selection itself:
+/// `system.init.model` reports the RESOLVED concrete id (selection `haiku` → init
+/// `claude-haiku-4-5`).
+///
+/// Runs ONLY when we sent a `set_model` (`desired` is `Some`). This is load-bearing,
+/// not an optimization: for the "Default" row we send nothing, and its own
+/// `resolvedModel` does NOT account for `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231: the
+/// `default` row reports `resolvedModel: claude-opus-4-8[1m]` while the process
+/// actually runs `claude-opus-5[1m]` from the env), so checking it would fire a false
+/// mismatch on every default session.
+fn reconcile_init_model(
+    frame: &serde_json::Value,
+    desired_model: &Arc<std::sync::Mutex<Option<String>>>,
+    discovered_caps: &Arc<std::sync::Mutex<DiscoveredCaps>>,
+    session_id: &str,
+) {
+    let desired = desired_model.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let resolved = discovered_caps
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .resolved_models
+        .clone();
+    match check_init_model(frame, desired.as_deref(), &resolved) {
+        InitModelCheck::NotChecked => {}
+        InitModelCheck::Applied { requested, running } => tracing::info!(
+            session_id = %session_id,
+            requested_model = %requested,
+            running_model = %running,
+            "claude set_model applied"
+        ),
+        InitModelCheck::Mismatch {
+            requested,
+            expected,
+            running,
+        } => tracing::warn!(
+            session_id = %session_id,
+            requested_model = %requested,
+            expected_model = %expected,
+            running_model = %running,
+            "claude set_model did NOT take effect — the session is running a different model"
+        ),
+    }
+}
+
+/// The pure verdict behind [`reconcile_init_model`], split out so the comparison rules
+/// are unit-testable without a live reader.
+#[derive(Debug, PartialEq, Eq)]
+enum InitModelCheck {
+    /// Not an init frame, no `set_model` was sent, no reported model, or no catalog row
+    /// to compare against.
+    NotChecked,
+    Applied {
+        requested: String,
+        running: String,
+    },
+    Mismatch {
+        requested: String,
+        expected: String,
+        running: String,
+    },
+}
+
+fn check_init_model(
+    frame: &serde_json::Value,
+    desired: Option<&str>,
+    resolved_models: &std::collections::HashMap<String, String>,
+) -> InitModelCheck {
+    use serde_json::Value;
+    if frame.get("type").and_then(Value::as_str) != Some("system")
+        || frame.get("subtype").and_then(Value::as_str) != Some("init")
+    {
+        return InitModelCheck::NotChecked;
+    }
+    let Some(desired) = desired else {
+        return InitModelCheck::NotChecked;
+    };
+    let Some(reported) = frame.get("model").and_then(Value::as_str) else {
+        return InitModelCheck::NotChecked;
+    };
+    // No catalog row (or a row without `resolvedModel`) → nothing to compare against.
+    // Silent: the catalog may simply not have landed on this process yet.
+    let Some(expected) = resolved_models.get(desired) else {
+        return InitModelCheck::NotChecked;
+    };
+    // A selection may be the concrete id itself, in which case the reported id equals it
+    // directly rather than going through the row's resolution.
+    if reported == expected || reported == desired {
+        return InitModelCheck::Applied {
+            requested: desired.to_owned(),
+            running: reported.to_owned(),
+        };
+    }
+    InitModelCheck::Mismatch {
+        requested: desired.to_owned(),
+        expected: expected.clone(),
+        running: reported.to_owned(),
+    }
+}
+
 /// B-CLAUDE-INIT: sniff a raw `system/init` frame for discovery data the legacy
 /// `parse_system` drops. Captures `model` into `discovered_model` (only when
 /// `want_init_model`, i.e. config supplied none) and emits a `Provisioning` event
@@ -2252,6 +2491,21 @@ fn sniff_control_initialize(
                 .collect()
         })
         .unwrap_or_default();
+    // Row id → concrete model, for the `set_model` landed-check (see
+    // `DiscoveredCaps::resolved_models`). Rows without the field are simply absent,
+    // which makes the check skip them rather than report a false mismatch.
+    let resolved_models: std::collections::HashMap<String, String> = models
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|m| {
+                    let id = m.get("value").and_then(Value::as_str)?.to_string();
+                    let resolved = m.get("resolvedModel").and_then(Value::as_str)?.to_string();
+                    Some((id, resolved))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let parsed_commands: Vec<SlashCommandInfo> = commands
         .map(|commands| {
             commands
@@ -2270,6 +2524,7 @@ fn sniff_control_initialize(
         let mut caps = discovered_caps.lock().unwrap_or_else(|e| e.into_inner());
         if models.is_some() {
             caps.models = parsed_models.clone();
+            caps.resolved_models = resolved_models;
         }
         if commands.is_some() {
             caps.slash_commands = parsed_commands.clone();
@@ -3051,6 +3306,13 @@ impl SessionBackend for ClaudeSessionBackend {
                 // model id surfaces only when the NEXT turn actually tries to use it (API
                 // 404). There is deliberately NO reader-side set_model response parser
                 // (it would be permanently inert + self-confirming — README discipline #9).
+                // Record the new pick so a later F-4 wake re-applies THIS model, not the
+                // open-time one. (Under the old `--model` flag a mid-session switch was
+                // silently lost on wake, because the wake recipe replays the open-time
+                // spawn args verbatim.) `default` maps to None — "send nothing" — so a
+                // woken process resolves the model from the user's config again.
+                *self.desired_model.lock().unwrap_or_else(|e| e.into_inner()) =
+                    desired_model_from_config(Some(model.as_str()));
                 let _ = self
                     .write_or_queue_control(serde_json::json!({ "subtype": "set_model", "model": model.clone() }))
                     .await?;
@@ -3531,8 +3793,10 @@ mod tests {
         );
     }
 
-    /// preset_context → `--append-system-prompt`; model → `--model`; mode →
-    /// `--permission-mode`; each omitted independently when its source is empty.
+    /// preset_context → `--append-system-prompt`; mode → `--permission-mode`; each
+    /// omitted independently when its source is empty. `model` is deliberately NOT
+    /// mapped to a flag — it is applied in-band via `set_model` (see
+    /// `desired_model_from_config` / `apply_desired_model`).
     #[test]
     fn build_claude_init_args_threads_preset_model_mode() {
         let config = SessionConfig {
@@ -3554,8 +3818,19 @@ mod tests {
             pair("--append-system-prompt").as_deref(),
             Some("[Assistant Rules] be precise")
         );
-        assert_eq!(pair("--model").as_deref(), Some("global.anthropic.claude-opus-4-8"));
         assert_eq!(pair("--permission-mode").as_deref(), Some("plan"));
+        // The model must NOT reach the command line: `--model default` overrides the
+        // user's own ANTHROPIC_MODEL, and any `--model` value reshapes the initialize
+        // catalog we persist for the picker (both LIVE-PROBED 2.1.231). A concrete id is
+        // no exception — the selection travels in-band for every value.
+        assert!(
+            !args.iter().any(|a| a == "--model"),
+            "the model selection must never be a spawn flag, got {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "global.anthropic.claude-opus-4-8"),
+            "no bare model value should leak into the args either, got {args:?}"
+        );
 
         // Whitespace-only / empty model & preset are omitted (not emitted as blank
         // flags), but `--permission-mode` is the SECURITY exception: a blank/missing
@@ -5305,6 +5580,236 @@ mod tests {
         assert!(
             set_model_at < second_prompt_at,
             "the queued set_model must be drained BEFORE the next prompt (else it truncates the turn), got: {written}"
+        );
+    }
+
+    /// The "Default" picker row means "send NO model" — because `--model default` (and,
+    /// by the same wire value, `set_model{default}`) OVERRIDES the user's own
+    /// `ANTHROPIC_MODEL` instead of deferring to it (LIVE-PROBED 2.1.231: with
+    /// `ANTHROPIC_MODEL=claude-opus-5[1m]`, `system.init.model` is `claude-opus-5[1m]`
+    /// with no flag but `claude-opus-4-8[1m]` with `--model default`).
+    #[test]
+    fn desired_model_from_config_suppresses_only_the_default_row() {
+        assert_eq!(desired_model_from_config(Some("default")), None, "the sentinel row");
+        assert_eq!(desired_model_from_config(Some("  default  ")), None, "trimmed sentinel");
+        assert_eq!(desired_model_from_config(None), None, "no selection at all");
+        assert_eq!(desired_model_from_config(Some("")), None, "empty");
+        assert_eq!(desired_model_from_config(Some("   ")), None, "whitespace only");
+        // Everything else travels in-band verbatim — aliases AND concrete ids.
+        assert_eq!(desired_model_from_config(Some("opus")), Some("opus".to_string()));
+        assert_eq!(desired_model_from_config(Some("haiku")), Some("haiku".to_string()));
+        assert_eq!(
+            desired_model_from_config(Some("claude-opus-4-8[1m]")),
+            Some("claude-opus-4-8[1m]".to_string())
+        );
+        assert_eq!(
+            desired_model_from_config(Some(" claude-opus-5[1m] ")),
+            Some("claude-opus-5[1m]".to_string()),
+            "trimmed, not dropped"
+        );
+    }
+
+    /// A selection travels as a `set_model` control_request on the spawn's stdin — the
+    /// replacement for the removed `--model` flag.
+    #[tokio::test]
+    async fn apply_desired_model_writes_set_model_for_a_real_selection() {
+        let fake = FakeAgentIo::never_exits(Vec::new());
+        let captured = fake.captured_stdin();
+        let backend = ClaudeSessionBackend::build_with_io("s", Box::new(fake)).await;
+
+        *backend.desired_model.lock().unwrap() = Some("haiku".into());
+        backend.apply_desired_model().await;
+
+        // The fake drains stdin into the capture buffer from a spawned task, so poll.
+        let written = poll_captured(&captured, |s| s.contains("set_model")).await;
+        assert!(
+            written.contains("set_model") && written.contains("haiku"),
+            "the selection must reach the wire as set_model, got: {written}"
+        );
+    }
+
+    /// Read the fake's captured stdin until `done` is satisfied (or a short deadline
+    /// passes), returning whatever was captured. The fake drains its stdin duplex from a
+    /// spawned task, so an immediate read races the write.
+    async fn poll_captured(captured: &Arc<tokio::sync::Mutex<Vec<u8>>>, done: impl Fn(&str) -> bool) -> String {
+        let mut seen = String::new();
+        for _ in 0..40 {
+            seen = String::from_utf8_lossy(&captured.lock().await.clone()).to_string();
+            if done(&seen) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        seen
+    }
+
+    /// The Default row writes NOTHING: sending `set_model{default}` would override the
+    /// user's `ANTHROPIC_MODEL`, which is exactly the bug this path exists to avoid.
+    #[tokio::test]
+    async fn apply_desired_model_writes_nothing_for_the_default_row() {
+        let fake = FakeAgentIo::never_exits(Vec::new());
+        let captured = fake.captured_stdin();
+        let backend = ClaudeSessionBackend::build_with_io("s", Box::new(fake)).await;
+
+        *backend.desired_model.lock().unwrap() = desired_model_from_config(Some("default"));
+        backend.apply_desired_model().await;
+
+        // Absence needs a barrier, not a sleep: write a prompt AFTER the (expected)
+        // no-op and wait for it, so "no set_model" is observed on a wire that has
+        // provably flushed everything apply_desired_model could have written.
+        backend
+            .dispatch(Command::Send {
+                content: vec![ContentBlock::Text("SENTINEL".into())],
+                metadata: CommandMeta::default(),
+            })
+            .await
+            .expect("Send accepted");
+        let written = poll_captured(&captured, |s| s.contains("SENTINEL")).await;
+        assert!(
+            written.contains("SENTINEL"),
+            "the barrier prompt must reach the wire, got: {written}"
+        );
+        assert!(
+            !written.contains("set_model"),
+            "the Default row must not send any model, got: {written}"
+        );
+    }
+
+    /// A mid-session switch must update the slot the WAKE path re-applies from,
+    /// otherwise an idle-reaped session silently reverts to the open-time model (which
+    /// is what the old `--model` flag did: the wake recipe replays the open-time args).
+    #[tokio::test]
+    async fn set_model_dispatch_updates_the_slot_the_wake_reapplies() {
+        let fake = FakeAgentIo::never_exits(Vec::new());
+        let backend = ClaudeSessionBackend::build_with_io("s", Box::new(fake)).await;
+
+        backend
+            .dispatch(Command::SetModel { model: "haiku".into() })
+            .await
+            .expect("SetModel accepted");
+        assert_eq!(
+            backend.desired_model.lock().unwrap().clone(),
+            Some("haiku".to_string()),
+            "a wake must re-apply the user's CURRENT pick"
+        );
+
+        // Switching back to Default clears it, so a woken process resolves the model
+        // from the user's own config again rather than re-pinning the old pick.
+        backend
+            .dispatch(Command::SetModel {
+                model: "default".into(),
+            })
+            .await
+            .expect("SetModel(default) accepted");
+        assert_eq!(
+            backend.desired_model.lock().unwrap().clone(),
+            None,
+            "Default must clear the slot, not pin the literal sentinel"
+        );
+    }
+
+    /// The initialize catalog carries `resolvedModel` per row — the only bridge between
+    /// our row-id selection and the concrete id `system/init` reports.
+    #[test]
+    fn initialize_response_captures_resolved_models() {
+        let caps = Arc::new(std::sync::Mutex::new(DiscoveredCaps::default()));
+        let (event_tx, _rx) = broadcast::channel(8);
+        // Shape live-captured from claude 2.1.231's initialize reply.
+        let frame = serde_json::json!({
+            "type": "control_response",
+            "response": { "subtype": "success", "request_id": "ctl-1", "response": { "models": [
+                {"value": "default", "resolvedModel": "claude-opus-4-8[1m]", "displayName": "Default"},
+                {"value": "haiku", "resolvedModel": "claude-haiku-4-5", "displayName": "claude-haiku-4-5"},
+                {"value": "global.anthropic.claude-fable-5", "resolvedModel": "global.anthropic.claude-fable-5", "displayName": "Fable"},
+                {"value": "no-resolved-field", "displayName": "Odd row"}
+            ]}}
+        });
+        sniff_control_initialize(&frame, &caps, &event_tx, "s", 0);
+
+        let resolved = caps.lock().unwrap().resolved_models.clone();
+        assert_eq!(resolved.get("default").map(String::as_str), Some("claude-opus-4-8[1m]"));
+        assert_eq!(resolved.get("haiku").map(String::as_str), Some("claude-haiku-4-5"));
+        assert_eq!(
+            resolved.get("global.anthropic.claude-fable-5").map(String::as_str),
+            Some("global.anthropic.claude-fable-5")
+        );
+        assert!(
+            !resolved.contains_key("no-resolved-field"),
+            "a row without resolvedModel is absent, so the check skips it instead of \
+             reporting a false mismatch"
+        );
+        assert_eq!(
+            caps.lock().unwrap().models.len(),
+            4,
+            "the picker still gets every row, resolvedModel or not"
+        );
+    }
+
+    /// The landed-check compares `system.init.model` against the SELECTED ROW's
+    /// `resolvedModel`, and stays silent whenever it has no ground to stand on.
+    #[test]
+    fn init_model_check_verdicts() {
+        let resolved: std::collections::HashMap<String, String> = [
+            ("default", "claude-opus-4-8[1m]"),
+            ("haiku", "claude-haiku-4-5"),
+            ("opus", "claude-opus-4-8[1m]"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        let init = |model: &str| serde_json::json!({"type": "system", "subtype": "init", "model": model});
+
+        // Applied: the row id resolves to exactly what claude reports running.
+        assert_eq!(
+            check_init_model(&init("claude-haiku-4-5"), Some("haiku"), &resolved),
+            InitModelCheck::Applied {
+                requested: "haiku".into(),
+                running: "claude-haiku-4-5".into()
+            }
+        );
+        // Mismatch: we asked for haiku, claude is running something else.
+        assert_eq!(
+            check_init_model(&init("claude-opus-5[1m]"), Some("haiku"), &resolved),
+            InitModelCheck::Mismatch {
+                requested: "haiku".into(),
+                expected: "claude-haiku-4-5".into(),
+                running: "claude-opus-5[1m]".into()
+            }
+        );
+        // The Default row sends nothing, so there is nothing to check — and checking it
+        // WOULD misfire: its resolvedModel ignores ANTHROPIC_MODEL, so a default session
+        // legitimately runs `claude-opus-5[1m]` while the row says `claude-opus-4-8[1m]`
+        // (LIVE-PROBED 2.1.231).
+        assert_eq!(
+            check_init_model(&init("claude-opus-5[1m]"), None, &resolved),
+            InitModelCheck::NotChecked,
+            "no set_model sent ⇒ no verdict"
+        );
+        // Catalog not landed yet / row unknown → silent, not a false alarm.
+        assert_eq!(
+            check_init_model(&init("whatever"), Some("haiku"), &std::collections::HashMap::new()),
+            InitModelCheck::NotChecked
+        );
+        assert_eq!(
+            check_init_model(&init("whatever"), Some("not-a-row"), &resolved),
+            InitModelCheck::NotChecked
+        );
+        // Non-init frames and init frames without a model are ignored.
+        assert_eq!(
+            check_init_model(
+                &serde_json::json!({"type": "system", "subtype": "status", "model": "x"}),
+                Some("haiku"),
+                &resolved
+            ),
+            InitModelCheck::NotChecked
+        );
+        assert_eq!(
+            check_init_model(
+                &serde_json::json!({"type": "system", "subtype": "init"}),
+                Some("haiku"),
+                &resolved
+            ),
+            InitModelCheck::NotChecked
         );
     }
 

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -2171,28 +2171,33 @@ fn register_or_clear_pending(
     }
 }
 
-/// Check that the in-band `set_model` we sent at spawn/wake actually took effect.
+/// Report the model this process run is ACTUALLY on, and check it against the in-band
+/// `set_model` we sent at spawn/wake.
 ///
-/// claude does NOT validate a model id: neither `--model <bogus>` nor
-/// `set_model{<bogus>}` fails at spawn — the id is echoed back in `system.init.model`
-/// verbatim and the turn only dies with `result{is_error:true}` once the user sends a
-/// message (LIVE-PROBED 2.1.231 for BOTH paths, so this is pre-existing behaviour, not
-/// a cost of going in-band). The primary guard is upstream: the app layer drops a
-/// selection that is not in the catalog before it is ever sent. This is the backstop
-/// for what upstream cannot see — a row that exists but resolves elsewhere, or a
-/// `set_model` claude silently ignored — so a "the model I picked is not the one
-/// running" report is diagnosable from an `info`-level production log.
+/// Every claude process run gets exactly one `info` line naming the concrete model it is
+/// running. That line is the only production-visible answer to "which model did this
+/// conversation actually use": the picker shows our ROW id (`opus`, `default`), the
+/// `--model` flag is gone, and a "Default" session sends nothing at all — so without it,
+/// the most common case (no explicit selection) would leave no trace whatsoever.
+///
+/// The check on top is needed because claude does NOT validate a model id: neither
+/// `--model <bogus>` nor `set_model{<bogus>}` fails at spawn — the id is echoed back in
+/// `system.init.model` verbatim and the turn only dies with `result{is_error:true}` once
+/// the user sends a message (LIVE-PROBED 2.1.231 for BOTH paths, so this is pre-existing
+/// behaviour, not a cost of going in-band). The primary guard is upstream: the app layer
+/// drops a selection that is not in the catalog before it is ever sent. This is the
+/// backstop for what upstream cannot see — a row that exists but resolves elsewhere, or a
+/// `set_model` claude silently ignored.
 ///
 /// Compares against `resolved_models[selection]`, NOT the selection itself:
 /// `system.init.model` reports the RESOLVED concrete id (selection `haiku` → init
 /// `claude-haiku-4-5`).
 ///
-/// Runs ONLY when we sent a `set_model` (`desired` is `Some`). This is load-bearing,
-/// not an optimization: for the "Default" row we send nothing, and its own
-/// `resolvedModel` does NOT account for `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231: the
-/// `default` row reports `resolvedModel: claude-opus-4-8[1m]` while the process
-/// actually runs `claude-opus-5[1m]` from the env), so checking it would fire a false
-/// mismatch on every default session.
+/// A run with NO selection sent is reported but never compared. That is load-bearing,
+/// not an optimization: the `default` row's own `resolvedModel` does NOT account for
+/// `ANTHROPIC_MODEL` (LIVE-PROBED 2.1.231 — the row reports
+/// `resolvedModel: claude-opus-4-8[1m]` while the process runs `claude-opus-5[1m]` from
+/// the env), so comparing against it would fire a false mismatch on every such session.
 fn reconcile_init_model(
     frame: &serde_json::Value,
     desired_model: &Arc<std::sync::Mutex<Option<String>>>,
@@ -2207,11 +2212,26 @@ fn reconcile_init_model(
         .clone();
     match check_init_model(frame, desired.as_deref(), &resolved) {
         InitModelCheck::NotChecked => {}
+        // No selection was sent, so claude resolved the model from the user's own config
+        // (`ANTHROPIC_MODEL` / account default) exactly as the terminal CLI does.
+        InitModelCheck::ResolvedByCli { running } => tracing::info!(
+            session_id = %session_id,
+            running_model = %running,
+            "claude session model resolved from the user's claude config (no selection sent)"
+        ),
         InitModelCheck::Applied { requested, running } => tracing::info!(
             session_id = %session_id,
             requested_model = %requested,
             running_model = %running,
             "claude set_model applied"
+        ),
+        // Reported, but the catalog row is missing (or carries no `resolvedModel`), so
+        // there is nothing to compare against — still worth naming the running model.
+        InitModelCheck::Unverified { requested, running } => tracing::info!(
+            session_id = %session_id,
+            requested_model = %requested,
+            running_model = %running,
+            "claude session running model (selection not verifiable: no catalog row yet)"
         ),
         InitModelCheck::Mismatch {
             requested,
@@ -2231,10 +2251,18 @@ fn reconcile_init_model(
 /// are unit-testable without a live reader.
 #[derive(Debug, PartialEq, Eq)]
 enum InitModelCheck {
-    /// Not an init frame, no `set_model` was sent, no reported model, or no catalog row
-    /// to compare against.
+    /// Not an init frame, or an init frame that names no model — nothing to report.
     NotChecked,
+    /// No selection was sent; the CLI resolved the model from the user's config.
+    ResolvedByCli {
+        running: String,
+    },
     Applied {
+        requested: String,
+        running: String,
+    },
+    /// A selection was sent but cannot be checked (no catalog row to resolve it).
+    Unverified {
         requested: String,
         running: String,
     },
@@ -2256,16 +2284,19 @@ fn check_init_model(
     {
         return InitModelCheck::NotChecked;
     }
-    let Some(desired) = desired else {
-        return InitModelCheck::NotChecked;
-    };
     let Some(reported) = frame.get("model").and_then(Value::as_str) else {
         return InitModelCheck::NotChecked;
     };
-    // No catalog row (or a row without `resolvedModel`) → nothing to compare against.
-    // Silent: the catalog may simply not have landed on this process yet.
+    let Some(desired) = desired else {
+        return InitModelCheck::ResolvedByCli {
+            running: reported.to_owned(),
+        };
+    };
     let Some(expected) = resolved_models.get(desired) else {
-        return InitModelCheck::NotChecked;
+        return InitModelCheck::Unverified {
+            requested: desired.to_owned(),
+            running: reported.to_owned(),
+        };
     };
     // A selection may be the concrete id itself, in which case the reported id equals it
     // directly rather than going through the row's resolution.
@@ -5776,23 +5807,33 @@ mod tests {
                 running: "claude-opus-5[1m]".into()
             }
         );
-        // The Default row sends nothing, so there is nothing to check — and checking it
-        // WOULD misfire: its resolvedModel ignores ANTHROPIC_MODEL, so a default session
-        // legitimately runs `claude-opus-5[1m]` while the row says `claude-opus-4-8[1m]`
-        // (LIVE-PROBED 2.1.231).
+        // No selection sent (the Default row): REPORTED but never compared. Comparing
+        // would misfire — the `default` row's resolvedModel ignores ANTHROPIC_MODEL, so
+        // such a session legitimately runs `claude-opus-5[1m]` while the row says
+        // `claude-opus-4-8[1m]` (LIVE-PROBED 2.1.231). Reporting it is the ONLY trace of
+        // what the most common case actually ran.
         assert_eq!(
             check_init_model(&init("claude-opus-5[1m]"), None, &resolved),
-            InitModelCheck::NotChecked,
-            "no set_model sent ⇒ no verdict"
+            InitModelCheck::ResolvedByCli {
+                running: "claude-opus-5[1m]".into()
+            },
+            "no set_model sent ⇒ report the running model, do not judge it"
         );
-        // Catalog not landed yet / row unknown → silent, not a false alarm.
+        // Catalog not landed yet / row unknown → report without a verdict, never a false
+        // alarm.
         assert_eq!(
             check_init_model(&init("whatever"), Some("haiku"), &std::collections::HashMap::new()),
-            InitModelCheck::NotChecked
+            InitModelCheck::Unverified {
+                requested: "haiku".into(),
+                running: "whatever".into()
+            }
         );
         assert_eq!(
             check_init_model(&init("whatever"), Some("not-a-row"), &resolved),
-            InitModelCheck::NotChecked
+            InitModelCheck::Unverified {
+                requested: "not-a-row".into(),
+                running: "whatever".into()
+            }
         );
         // Non-init frames and init frames without a model are ignored.
         assert_eq!(

--- a/crates/aionui-session/tests/live_claude_model.rs
+++ b/crates/aionui-session/tests/live_claude_model.rs
@@ -107,9 +107,9 @@ where
     }
 }
 
-/// Open a claude session with `model`, run one tiny turn, and report the concrete model
-/// it actually ran (`None` when nothing was observed).
-async fn running_model_for(model: Option<&str>) -> Option<String> {
+/// Open a claude session with `model`, run one tiny turn, and report
+/// `(reconcile message, concrete model it actually ran)`.
+async fn observe_run(model: Option<&str>) -> Option<(String, String)> {
     let spy = global_spy();
     spy.clear();
 
@@ -145,12 +145,17 @@ async fn running_model_for(model: Option<&str>) -> Option<String> {
 
     // The reconcile fires on `system/init`, which claude emits once the turn starts.
     for _ in 0..120 {
-        if let Some((_, running)) = spy.seen().into_iter().next_back() {
-            return Some(running);
+        if let Some(seen) = spy.seen().into_iter().next_back() {
+            return Some(seen);
         }
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
     }
     None
+}
+
+/// Just the concrete model a run ended up on.
+async fn running_model_for(model: Option<&str>) -> Option<String> {
+    observe_run(model).await.map(|(_, running)| running)
 }
 
 /// The model AionUi asks for is the model claude runs — end to end, through the real
@@ -170,29 +175,35 @@ async fn selection_is_the_model_that_actually_runs() {
     );
 }
 
-/// The "Default" row must NOT pin a model: it sends nothing, so claude resolves the user
-/// config exactly as the terminal CLI does. Asserted as a DIFFERENCE against an explicit
-/// selection, so it holds for any user's env.
+/// "No selection" and "the `default` row" are two DIFFERENT intents, and both must land
+/// where the terminal CLI lands:
 ///
-/// This is the regression that started all of this: mapping Default to `--model default`
-/// overrode the user's own `ANTHROPIC_MODEL` and silently ran a different model.
+/// - no selection  → whatever the user's config resolves to (CLI startup state)
+/// - `default` row → the ACCOUNT default, overriding `ANTHROPIC_MODEL` (CLI's row 1,
+///   whose own description reads "Use the default model (currently ...)")
+///
+/// Asserted through the reconcile VERDICT rather than a hard-coded id, so it holds on any
+/// machine: a `default` run must be CONFIRMED against that row's `resolvedModel`, while a
+/// no-selection run is only reported (no row predicts it).
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "LIVE: spawns the real claude CLI and spends tokens"]
-async fn default_row_defers_to_the_user_config_instead_of_pinning_a_model() {
-    let via_default_row = running_model_for(Some("default"))
+async fn default_row_and_no_selection_are_different_intents() {
+    let (default_msg, default_model) = observe_run(Some("default"))
         .await
         .expect("every run reports its model, selection or not");
-    let via_no_selection = running_model_for(None)
+    let (none_msg, none_model) = observe_run(None)
         .await
         .expect("every run reports its model, selection or not");
-    println!("Default row ran: {via_default_row} | no selection ran: {via_no_selection}");
+    println!("`default` row ran: {default_model} ({default_msg})");
+    println!("no selection ran:  {none_model} ({none_msg})");
 
-    // The invariant, independent of whose machine this runs on: our Default row must be
-    // INDISTINGUISHABLE from making no selection at all. `--model default` broke exactly
-    // this — it pinned the account default and ignored the user's ANTHROPIC_MODEL, so the
-    // two diverged (probed: claude-opus-4-8[1m] vs claude-opus-5[1m]).
-    assert_eq!(
-        via_default_row, via_no_selection,
-        "the Default row must defer to the user's config, not pin a model"
+    assert!(
+        default_msg.contains("set_model applied"),
+        "picking `default` must be SENT and confirmed against that row's resolvedModel, \
+         got: {default_msg}"
+    );
+    assert!(
+        none_msg.contains("resolved from the user's claude config"),
+        "making no pick must send nothing and be reported as config-resolved, got: {none_msg}"
     );
 }

--- a/crates/aionui-session/tests/live_claude_model.rs
+++ b/crates/aionui-session/tests/live_claude_model.rs
@@ -179,17 +179,20 @@ async fn selection_is_the_model_that_actually_runs() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "LIVE: spawns the real claude CLI and spends tokens"]
 async fn default_row_defers_to_the_user_config_instead_of_pinning_a_model() {
-    // Default sends no set_model, so the reconcile stays silent by design — the
-    // observable is that an explicit selection DOES move the model, i.e. Default is not
-    // silently forcing the same one.
-    assert_eq!(
-        running_model_for(Some("default")).await,
-        None,
-        "the Default row must send no set_model at all (nothing to reconcile)"
-    );
-
-    let explicit = running_model_for(Some("haiku"))
+    let via_default_row = running_model_for(Some("default"))
         .await
-        .expect("an explicit selection must be observable");
-    println!("explicit selection ran: {explicit}");
+        .expect("every run reports its model, selection or not");
+    let via_no_selection = running_model_for(None)
+        .await
+        .expect("every run reports its model, selection or not");
+    println!("Default row ran: {via_default_row} | no selection ran: {via_no_selection}");
+
+    // The invariant, independent of whose machine this runs on: our Default row must be
+    // INDISTINGUISHABLE from making no selection at all. `--model default` broke exactly
+    // this — it pinned the account default and ignored the user's ANTHROPIC_MODEL, so the
+    // two diverged (probed: claude-opus-4-8[1m] vs claude-opus-5[1m]).
+    assert_eq!(
+        via_default_row, via_no_selection,
+        "the Default row must defer to the user's config, not pin a model"
+    );
 }

--- a/crates/aionui-session/tests/live_claude_model.rs
+++ b/crates/aionui-session/tests/live_claude_model.rs
@@ -1,0 +1,195 @@
+//! LIVE tests (`#[ignore]`) for claude's model selection, run against the real
+//! `claude` binary on PATH through the production `RealSpawner` + `ClaudeConnection`.
+//!
+//! These exist because the whole selection mechanism rests on claude-CLI behaviour that
+//! cannot be asserted from a fixture: `--model default` overriding `ANTHROPIC_MODEL`,
+//! the `initialize` catalog changing shape per `--model` value, and `--resume` NOT
+//! restoring a session's model. A green fake-IO suite proves our framing, not that the
+//! CLI does what we think.
+//!
+//! Last run green against claude 2.1.231.
+//!
+//! Run explicitly (needs a working `claude` login + spends a few tokens):
+//!
+//! ```text
+//! cargo test -p aionui-session --test live_claude_model -- --ignored --nocapture
+//! ```
+//!
+//! Environment note: the effective model depends on the user's own
+//! `~/.claude/settings.json` env block (`ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_*`), so
+//! these assert RELATIVE facts — "the model we asked for is the one running", "a
+//! selection changes the running model, and Default does not pin it" — never a
+//! hard-coded model id.
+
+use std::sync::{Arc, Mutex};
+
+use aionui_process::Spawner;
+use aionui_session::{
+    BackendConnection, ClaudeConnection, Command, CommandMeta, ContentBlock, SessionConfig, SessionSpec,
+};
+
+/// Capture the `running_model` field of the reconcile log line — the only place the
+/// CONCRETE model a session ended up on is observable (claude reports it in
+/// `system/init`, which the session API otherwise only surfaces when no selection was
+/// made).
+#[derive(Clone, Default)]
+struct ModelSpy(Arc<Mutex<Vec<(String, String)>>>);
+
+impl ModelSpy {
+    /// `(message, running_model)` pairs seen so far.
+    fn seen(&self) -> Vec<(String, String)> {
+        self.0.lock().unwrap().clone()
+    }
+
+    fn clear(&self) {
+        self.0.lock().unwrap().clear();
+    }
+}
+
+/// The spy must be installed GLOBALLY, not per-thread: the reconcile runs on the
+/// backend's reader task, which tokio may schedule on any worker thread, so a
+/// thread-local `set_default` subscriber would never see it.
+fn global_spy() -> ModelSpy {
+    use tracing_subscriber::Layer as _;
+    use tracing_subscriber::layer::SubscriberExt;
+    static SPY: std::sync::OnceLock<ModelSpy> = std::sync::OnceLock::new();
+    SPY.get_or_init(|| {
+        let spy = ModelSpy::default();
+        let subscriber = tracing_subscriber::registry()
+            .with(spy.clone())
+            // Mirror to stderr so a failure shows WHY (spawn error, no init frame, ...)
+            // instead of just "nothing observed".
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+            );
+        tracing::subscriber::set_global_default(subscriber).expect("install the live-test subscriber");
+        spy
+    })
+    .clone()
+}
+
+impl<S> tracing_subscriber::Layer<S> for ModelSpy
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        struct Grab {
+            message: String,
+            running: Option<String>,
+        }
+        impl tracing::field::Visit for Grab {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                let rendered = format!("{value:?}").trim_matches('"').to_string();
+                match field.name() {
+                    "message" => self.message = rendered,
+                    "running_model" => self.running = Some(rendered),
+                    _ => {}
+                }
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                match field.name() {
+                    "message" => self.message = value.to_owned(),
+                    "running_model" => self.running = Some(value.to_owned()),
+                    _ => {}
+                }
+            }
+        }
+        let mut grab = Grab {
+            message: String::new(),
+            running: None,
+        };
+        event.record(&mut grab);
+        if let Some(running) = grab.running {
+            self.0.lock().unwrap().push((grab.message, running));
+        }
+    }
+}
+
+/// Open a claude session with `model`, run one tiny turn, and report the concrete model
+/// it actually ran (`None` when nothing was observed).
+async fn running_model_for(model: Option<&str>) -> Option<String> {
+    let spy = global_spy();
+    spy.clear();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spawner: Arc<dyn Spawner> = Arc::new(aionui_process::RealSpawner::new(
+        Arc::new(aionui_process::FileRegistryStore::new(tmp.path())),
+        uuid::Uuid::now_v7(),
+        "live-test",
+    ));
+    let conn = ClaudeConnection::new(spawner);
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let backend = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: session_id.clone(),
+            },
+            SessionConfig {
+                cwd: Some(tmp.path().to_string_lossy().to_string()),
+                model: model.map(str::to_owned),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("claude session opens (is `claude` on PATH and logged in?)");
+
+    backend
+        .dispatch(Command::Send {
+            content: vec![ContentBlock::Text("say ok".into())],
+            metadata: CommandMeta::default(),
+        })
+        .await
+        .expect("prompt accepted");
+
+    // The reconcile fires on `system/init`, which claude emits once the turn starts.
+    for _ in 0..120 {
+        if let Some((_, running)) = spy.seen().into_iter().next_back() {
+            return Some(running);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    None
+}
+
+/// The model AionUi asks for is the model claude runs — end to end, through the real
+/// spawn, with NO `--model` flag involved (the selection travels in-band).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "LIVE: spawns the real claude CLI and spends tokens"]
+async fn selection_is_the_model_that_actually_runs() {
+    let haiku = running_model_for(Some("haiku"))
+        .await
+        .expect("no reconcile line observed — did system/init never arrive?");
+    println!("selection `haiku` ran: {haiku}");
+    // `haiku` is claude's own alias row; its concrete id is whatever the user's
+    // ANTHROPIC_DEFAULT_HAIKU_MODEL resolves to, so match on the family, not an id.
+    assert!(
+        haiku.to_ascii_lowercase().contains("haiku"),
+        "asked for the haiku row, claude ran `{haiku}`"
+    );
+}
+
+/// The "Default" row must NOT pin a model: it sends nothing, so claude resolves the user
+/// config exactly as the terminal CLI does. Asserted as a DIFFERENCE against an explicit
+/// selection, so it holds for any user's env.
+///
+/// This is the regression that started all of this: mapping Default to `--model default`
+/// overrode the user's own `ANTHROPIC_MODEL` and silently ran a different model.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "LIVE: spawns the real claude CLI and spends tokens"]
+async fn default_row_defers_to_the_user_config_instead_of_pinning_a_model() {
+    // Default sends no set_model, so the reconcile stays silent by design — the
+    // observable is that an explicit selection DOES move the model, i.e. Default is not
+    // silently forcing the same one.
+    assert_eq!(
+        running_model_for(Some("default")).await,
+        None,
+        "the Default row must send no set_model at all (nothing to reconcile)"
+    );
+
+    let explicit = running_model_for(Some("haiku"))
+        .await
+        .expect("an explicit selection must be observable");
+    println!("explicit selection ran: {explicit}");
+}


### PR DESCRIPTION
## Problem

For the `claude` backend, the model picker disagreed with `claude`'s own `/model` list, showed a *different* list in two environments on the same machine running the same CLI build, and could never offer the model the CLI itself was configured to use. Picking `Default` then ran a model other than the one that row advertises.

## Root cause

Two independent defects, both verified by probing the real CLI (2.1.231) rather than inferred.

**1. The spawn flag reshaped the catalog it was read from.**

The selection was passed as `--model <id>`, and the `initialize` reply's `models[]` is a *function* of that flag:

| spawn | catalog |
|---|---|
| no `--model` | 6 rows, the last derived from the user's `ANTHROPIC_MODEL` |
| `--model default` | 6 rows, but that last row becomes the account default |
| `--model <alias>` | 5 rows, the last row is gone entirely |

The catalog is persisted per *agent* (last write wins), so a session opened on an alias **erased a row the picker was offering every other conversation**, and the `ANTHROPIC_MODEL` row was unreachable no matter what the user picked. This accounts for the whole "two environments show different lists" symptom — same binary, different last-spawned selection.

**2. `--model default` is not a no-op.**

It overrides the user's own `ANTHROPIC_MODEL`. With `ANTHROPIC_MODEL` set, `system.init.model` reports that model with no flag, but the account default with `--model default` — so a session ran a different model than `claude` would for the same config.

## Changes

**Spawn flagless; carry the selection in-band via `control_request{set_model}`.**

The flag would carry the model fine; it is disqualified because it also mutates the catalog. `set_model` does not (probed: the catalog is unchanged after one), so the persisted list is now constant *and* identical to what `/model` lists in a terminal.

- Applied before the first turn, so `system/init` already reports the switched model — no window where a turn runs on the wrong one.
- **Re-applied on every idle-wake respawn**, because `--resume` does *not* restore a session's model (probed). The previous flag was replayed verbatim from the open-time spawn args, so a mid-session switch was silently lost on wake; the selection now lives in a shared slot that `SetModel` rewrites.

**Distinguish "no selection" from the `default` row by presence, not by value.**

| session carries | sent | runs |
|---|---|---|
| no model | nothing | whatever the user's config resolves to (CLI startup behaviour) |
| `default` | `set_model default` | the account default (the CLI's own row 1) |
| any other row | that row | that row |

`default` is a real choice, not a synonym for "unpicked" — suppressing it made the picker contradict itself, since that row's description promises the account default. The companion AionUi change stops substituting an agent's cached catalog state for an absent user pick, which is what produced stray `default` selections.

**Guard the id on both sides.** No backend validates a model id at spawn — a bogus one is echoed into `system.init.model` and only fails once the user sends a message (probed for both the flag and the in-band path, so this is pre-existing behaviour). A selection absent from the agent's catalog is now dropped before it is sent, and a mismatch between the reported model and the selected row's `resolvedModel` is logged.

**Report the model every run actually uses.** With the flag gone and an unpicked session sending nothing, there was no production-visible answer to "which model did this conversation use". Every process run now emits one `info` line naming the concrete model, with a verdict when one can be given (applied / not verifiable / `warn` on mismatch).

## Tests

- Unit coverage for: no `--model` in the spawn args, the in-band apply and its no-op case, `SetModel` updating the slot the wake re-applies from, `resolvedModel` capture, the full verdict table, and the drop-if-not-in-catalog guard — including pass-through on an absent or empty catalog, so a first-ever open of any backend is provably unaffected.
- Three tests that asserted the old flag behaviour were rewritten rather than weakened, keeping their original subject.
- New `#[ignore]` live suite driving the real CLI through the production spawner, asserting through the reconcile verdict rather than hard-coded model ids so it holds on any machine.

## Manual validation

Verified in a development build against the real CLI, comparing the running model reported by the process against what the conversation itself answered:

- Picking an alias row, a concrete row, and `Default` each ran the corresponding model — all confirmed, no mismatch warnings.
- The previously unreachable model (the one the CLI resolves from the user's config) is now listed, selectable, and confirmed running.
- The persisted catalog matches the CLI's `/model` list row for row, and stays stable across sessions that pick different models — the behaviour that used to drift.
- Switching the active provider configuration mid-run correctly changed what an alias row resolves to, and the check confirmed it against the live catalog rather than a stale expectation.
- A session whose `initialize` reply had not landed before its first turn degraded to "reported, not verified" instead of raising a false mismatch, and its turn completed normally.

## Behaviour change

Conversations that had stored the `default` row are deliberately **not** migrated: they have always displayed `Default`, so honouring it makes behaviour match the label for the first time. Such a conversation moves from the user's `ANTHROPIC_MODEL` model to the account default. Worth a release note.

## Cross-repo

Needs the companion AionUi change for the complete semantics. Either side can ship first without breaking: shipping AionUi alone sends no override, which older backends already treat as "no flag"; shipping this alone leaves the frontend substituting a cached selection, which is the verified-correct `default` behaviour.
