### PR TITLE
fix(cli): register unindexed top-level subcommands in the capability index

### DIFF
--- a/crates/aionui-app/src/commands/cmd_capabilities.rs
+++ b/crates/aionui-app/src/commands/cmd_capabilities.rs
@@ -105,9 +105,29 @@ fn data() -> Value {
                     "runtime_token_required_for_context_and_call": true,
                     "does_not_accept_identity_authority_from_stdin": true
                 }
+            },
+            {
+                "name": "session",
+                "mode": "cross-session-messaging",
+                "description": "Deliver a message to another one of this user's conversations, and list the conversations that can receive one.",
+                "contract": "agent-facing-session-cli",
+                "contract_command": "session capabilities",
+                "invocation": "aioncore session capabilities",
+                "runtime_required": ["AIONUI_BASE_URL", "AIONUI_CONVERSATION_ID", "AIONUI_USER_ID", "AIONUI_RUNTIME_TOKEN"],
+                "runtime_free_commands": ["session capabilities"],
+                "safety": {
+                    "can_write": true,
+                    "runtime_token_required_for_context_and_call": true,
+                    "does_not_accept_identity_authority_from_stdin": true,
+                    "per_user_feature_switch": "list and send-message answer feature_disabled while the user has cross-session messaging switched off; capabilities stays available because it reads no conversation data"
+                }
             }
         ],
         "non_agent_subcommands": [
+            {
+                "name": "antigravity-hook",
+                "description": "PreToolUse permission gate spawned by the Antigravity CLI (agy) over stdin/stdout, not invoked by agents."
+            },
             {
                 "name": "doctor",
                 "description": "Human/developer self-check for agent backend availability."
@@ -119,6 +139,14 @@ fn data() -> Value {
             {
                 "name": "prepare-managed-resources",
                 "description": "Packaging helper for managed runtime resources."
+            },
+            {
+                "name": "secret",
+                "description": "Operator CLI for the storage-encryption root key. Opens the data-dir database directly and exits."
+            },
+            {
+                "name": "user",
+                "description": "Operator CLI for local user accounts. Opens the data-dir database directly and exits; bootstrap path for self-hosted deployments."
             }
         ]
     })
@@ -138,4 +166,115 @@ fn print_envelope(data: Value) -> Result<(), ()> {
         .write_all(rendered.as_bytes())
         .and_then(|_| stdout.write_all(b"\n"))
         .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+    use crate::cli::Cli;
+    use crate::commands::{config_capabilities, diagnose_capabilities, session_capabilities, team_capabilities};
+
+    /// `capabilities` is its own entrypoint — `data()` declares it under
+    /// `entrypoint`, not as one of the domains it indexes.
+    const SELF_DECLARED: [&str; 1] = ["capabilities"];
+
+    /// Every name this index advertises, across both buckets.
+    fn indexed_names() -> Vec<String> {
+        let data = data();
+        ["domains", "non_agent_subcommands"]
+            .into_iter()
+            .flat_map(|bucket| {
+                data[bucket]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{bucket} should be an array"))
+                    .iter()
+                    .map(|entry| {
+                        entry["name"]
+                            .as_str()
+                            .unwrap_or_else(|| panic!("{bucket} entry has no name: {entry}"))
+                            .to_owned()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    fn cli_subcommand_names() -> Vec<String> {
+        Cli::command()
+            .get_subcommands()
+            .map(|sub| sub.get_name().to_owned())
+            .collect()
+    }
+
+    /// An agent that runs `aioncore capabilities` sees only what this index
+    /// lists. A wired subcommand missing from both buckets is invisible — the
+    /// exact failure that hid `session` and `antigravity-hook` after they
+    /// shipped. Classifying every subcommand is what makes the index a
+    /// complete answer instead of a partial one.
+    #[test]
+    fn every_cli_subcommand_is_classified_by_the_index() {
+        let indexed = indexed_names();
+        let unclassified: Vec<String> = cli_subcommand_names()
+            .into_iter()
+            .filter(|name| !SELF_DECLARED.contains(&name.as_str()))
+            .filter(|name| !indexed.contains(name))
+            .collect();
+        assert!(
+            unclassified.is_empty(),
+            "these subcommands exist but appear in neither `domains` nor `non_agent_subcommands`: {unclassified:?}\n\
+             add each one to the bucket it belongs to in cmd_capabilities::data()"
+        );
+    }
+
+    /// The reverse direction: a renamed or removed subcommand leaves the index
+    /// advertising a path that can only fail.
+    #[test]
+    fn every_indexed_name_is_a_wired_cli_subcommand() {
+        let actual = cli_subcommand_names();
+        let dangling: Vec<String> = indexed_names()
+            .into_iter()
+            .filter(|name| !actual.contains(name))
+            .collect();
+        assert!(
+            dangling.is_empty(),
+            "the index advertises these names, but no such subcommand is wired: {dangling:?}"
+        );
+    }
+
+    /// Each domain entry points at a contract string that the domain's own
+    /// `capabilities` declares. When they drift, the index sends agents to a
+    /// contract name that nothing answers to.
+    #[test]
+    fn each_domain_entry_matches_the_contract_its_own_capabilities_declares() {
+        let data = data();
+        let domains = data["domains"].as_array().expect("domains should be an array");
+        for (name, own) in [
+            ("config", config_capabilities::data()),
+            ("diagnose", diagnose_capabilities::data()),
+            ("team", team_capabilities::data()),
+            ("session", session_capabilities::data()),
+        ] {
+            let entry = domains
+                .iter()
+                .find(|domain| domain["name"] == json!(name))
+                .unwrap_or_else(|| panic!("`{name}` is missing from the top-level domain index"));
+            assert_eq!(
+                entry["contract"], own["contract"],
+                "`{name}` is indexed as {} but its own capabilities declares {}",
+                entry["contract"], own["contract"]
+            );
+            assert_eq!(
+                entry["contract_command"],
+                json!(format!("{name} capabilities")),
+                "`{name}` contract_command should name its own capabilities command"
+            );
+            assert_eq!(
+                entry["invocation"],
+                json!(format!("aioncore {name} capabilities")),
+                "`{name}` invocation should be runnable verbatim"
+            );
+        }
+    }
 }

--- a/crates/aionui-app/tests/capabilities_cli_e2e.rs
+++ b/crates/aionui-app/tests/capabilities_cli_e2e.rs
@@ -55,4 +55,27 @@ async fn top_level_capabilities_prints_domain_index_without_runtime_env() {
     assert_eq!(diagnose["mode"], "read-only");
     assert_eq!(diagnose["contract_command"], "diagnose capabilities");
     assert_eq!(diagnose["invocation"], "aioncore diagnose capabilities");
+
+    let session = domains
+        .iter()
+        .find(|domain| domain["name"] == "session")
+        .expect("session domain should be advertised");
+    assert_eq!(session["mode"], "cross-session-messaging");
+    assert_eq!(session["contract_command"], "session capabilities");
+    assert_eq!(session["invocation"], "aioncore session capabilities");
+    // `session capabilities` is reachable with the feature switched off and
+    // without a runtime token, so the index must not claim otherwise.
+    assert_eq!(
+        session["runtime_free_commands"],
+        serde_json::json!(["session capabilities"])
+    );
+
+    let non_agent = stdout["data"]["non_agent_subcommands"]
+        .as_array()
+        .expect("non_agent_subcommands should be an array");
+    assert!(
+        non_agent.iter().any(|entry| entry["name"] == "antigravity-hook"),
+        "antigravity-hook is spawned by agy, not by agents — it must be declared \
+         as a non-agent subcommand rather than left out of the index: {non_agent:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Four wired top-level subcommands of the `aioncore` binary — `session`, `antigravity-hook`, `user` and `secret` — appeared in neither `domains` nor `non_agent_subcommands` of the top-level `aioncore capabilities` index. An agent reading that index, the only entry point for discovering the CLI surface without prior knowledge, could not see that the `session` domain exists at all, even though it carries a complete self-describing `session capabilities` contract.

This was drift, not a deliberate omission. `team` is taught primarily through prompt injection and was still indexed, so "taught elsewhere" was never the criterion for leaving a domain out. Nothing enforced the index, so each gap passed CI silently.

## The invariant proved itself before this PR merged

The first version of this branch registered `session` and `antigravity-hook`. While it was open, `user` and `secret` landed on `main` from an unrelated auth PR — also unindexed. CI runs against the merge result, so the new invariant failed immediately and named both. That is the exact class of omission this test exists to catch, produced by a different change and a different author, and caught without anyone having to remember the index. Those two entries are now registered as well.

Registering them widens this PR slightly beyond the two subcommands it started with. That is inherent to adding a completeness gate: exempting the newcomers instead would defeat the test.

## Changes

- Add the `session` domain to `domains`: its contract, the runtime environment variables its non-`capabilities` commands require, the runtime-free `session capabilities` command, and the per-user feature switch under which `list` / `send-message` answer `feature_disabled` while `capabilities` stays reachable.
- Add `antigravity-hook`, `secret` and `user` to `non_agent_subcommands`. None is an agent-invocable domain: the first is spawned by the Antigravity CLI over stdin/stdout; the other two are operator commands that open the data-dir database directly and exit. Neither `cmd_user.rs` nor `cmd_secret.rs` declares an agent-facing contract.
- Add a closure invariant over clap's own subcommand list, in both directions:
  - every wired subcommand must appear in one of the two buckets (`capabilities` itself is exempt as the declared entrypoint), so a new subcommand cannot ship unindexed;
  - every indexed name must resolve to a real subcommand, so a rename or removal cannot leave the index advertising a dead path.
- Add a cross-check that each domain entry names the contract string its own `capabilities` command declares, and that its `contract_command` / `invocation` are runnable verbatim.
- Extend the top-level capabilities e2e test with the same assertions against the real binary.

No behaviour change beyond the index payload. `schema_version` is unchanged: adding entries is purely additive and backward compatible. No new logs — the only failure mode already emits a stable `CAPABILITIES_STDOUT_WRITE_FAILED` line.

## Design decisions worth a reviewer's attention

- **clap introspection instead of a hand-written variant list.** The invariant walks `Cli::command().get_subcommands()` rather than an exhaustive `match` over `Command`. An exhaustive `match` would prove a classifier covers every variant but not that the test iterated them, and it would need a second hand-maintained list — another place to drift. clap's subcommand list is the surface an agent actually sees.
- **The invariant lives in a bin-crate unit test.** `cli.rs` and `commands/` are binary-only modules, so an integration test under `tests/` cannot reach the `Command` enum from Rust. Keeping the test beside `data()` also avoids widening any visibility.
- **Runtime environment is not derived from each domain's own capabilities.** The other three domain entries are hand-written literals; deriving only `session` would be inconsistent, and unifying all four is a larger refactor deliberately left out of scope. The contract cross-check covers the rename case that matters most.
- **`mode` is `cross-session-messaging`, not `read-write`.** `team` already established domain-shaped values over read/write ones, and `read-write` would misdescribe a command whose write target is another conversation's turn.

## Test plan

- [x] `cargo test -p aionui-app` — every new assertion was watched failing first: the closure invariant named exactly `["session", "antigravity-hook"]` before the entries were added, then exactly `["user", "secret"]` after the rebase onto main, and the e2e failed on the missing `session` domain
- [x] `cargo clippy -p aionui-app --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Full pre-push gate via `just push`, re-run after rebasing onto current main

Verified against a locally built backend in a development environment:

- [x] the index printed by the running binary lists `session` among the domains and the operator commands among the non-agent subcommands
- [x] `session capabilities` succeeds with no runtime environment variables set, as the index's `runtime_free_commands` claims
- [x] an agent in a real conversation, invoking the CLI through the injected helper-binary environment variable, read the index and reported the new entries — confirming the discovery path end to end, not just the function's return value
- [x] the same agent resolved `session capabilities` and returned the contract string the index advertises

The agent was asked to read the index explicitly, because the auto-injected cross-session-messaging skill already teaches the `session` CLI directly and would otherwise mask whether the index itself was consulted.
