### PR TITLE
perf: slim auto-inject skill descriptions to the injection budget

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/aionui-config/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/aionui-config/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aionui-config
-description: >-
-  Configure AionUi itself through the bundled aioncore config CLI: create and edit assistants, update assistant rules, inspect and import skills, manage MCP servers, configure model providers, update settings, manage agents, configure scheduled tasks, and manage app configuration from an agent conversation. Use when the user wants you to set up or modify an AionUi assistant, attach skills, change an assistant's system prompt, add MCP or model provider configuration, schedule recurring work, or otherwise configure their AionUi installation, including when the user needs to know whether assistant changes affect the current conversation or only new conversations.
+description: Configure AionUi itself with the bundled aioncore CLI. Use when asked to set up or change assistants, assistant rules, skills, MCP servers, model providers, agents, scheduled tasks, or settings.
 ---
 
 # AionUi Config

--- a/crates/aionui-app/assets/builtin-skills/auto-inject/officecli/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/officecli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: officecli
-description: Create, analyze, proofread, and modify Office documents (.docx, .xlsx, .pptx) using the officecli CLI tool. Use when the user wants to create, inspect, check formatting, find issues, add charts, or modify Office documents.
+description: Create, analyze, proofread, and modify Office documents (.docx, .xlsx, .pptx) with the officecli CLI. Use when the user wants to build, inspect, check formatting, or chart a Word/Excel/PPT file.
 ---
 
 > **⚠️ Platform note — read before running any command.** The shell snippets in this skill are written for **macOS / Linux** (bash/zsh). Always check which OS you are on first. On **Windows** do **not** run them verbatim — the underlying tool/CLI commands are usually cross-platform, but the surrounding shell syntax is not. Translate it to PowerShell before running:

--- a/crates/aionui-app/assets/builtin-skills/auto-inject/skill-creator/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: Guide for creating effective skills. Use when the user wants to create a new skill or update an existing one to extend Claude with specialized knowledge, workflows, or tool integrations.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -3423,6 +3423,50 @@ mod tests {
         }
     }
 
+    /// Auto-inject descriptions are a per-session resident cost: they are
+    /// injected into every conversation's skills index and count toward a
+    /// native CLI's always-on catalog. Keep each one inside the budget so
+    /// no description is ever truncated mid-sentence.
+    const MAX_AUTO_INJECT_DESCRIPTION_CHARS: usize = 200;
+
+    #[test]
+    fn auto_inject_skill_descriptions_stay_within_injection_budget() {
+        let auto_dir = BUILTIN_SKILLS
+            .get_dir(BUILTIN_AUTO_SKILLS_SUBDIR)
+            .expect("embedded corpus must contain the auto-inject subdirectory");
+
+        let mut checked = 0;
+        let mut failures = Vec::new();
+
+        for subdir in auto_dir.dirs() {
+            let location = subdir.path().join(SKILL_MANIFEST_FILE);
+            let Some(file) = BUILTIN_SKILLS.get_file(&location) else {
+                failures.push(format!("{}: missing {SKILL_MANIFEST_FILE}", subdir.path().display()));
+                continue;
+            };
+
+            let content = std::str::from_utf8(file.contents())
+                .unwrap_or_else(|err| panic!("{}: not UTF-8: {err}", location.display()));
+            // Measure the parsed value, not the raw YAML: a folded block
+            // scalar is what gets injected, not the `>-` source text.
+            let (_, description) = parse_frontmatter_fields(content)
+                .unwrap_or_else(|| panic!("{}: invalid frontmatter or missing description", location.display()));
+
+            checked += 1;
+            let length = description.chars().count();
+            if length > MAX_AUTO_INJECT_DESCRIPTION_CHARS {
+                failures.push(format!("{}: description is {length} chars", location.display()));
+            }
+        }
+
+        assert!(checked >= 5, "expected at least 5 auto-inject skills, got {checked}");
+        assert!(
+            failures.is_empty(),
+            "auto-inject skill descriptions must stay within {MAX_AUTO_INJECT_DESCRIPTION_CHARS} chars:\n{}",
+            failures.join("\n")
+        );
+    }
+
     #[tokio::test]
     async fn embedded_lists_auto_inject_from_corpus() {
         let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Auto-inject skill descriptions are a per-session resident cost: they are injected into every conversation's skills index and count toward a native CLI's always-on catalog, so their length is paid on every conversation whether or not the skill is used.

`aionui-config` alone was 666 chars — 47% of the entire index — because its description duplicated the command list that `aioncore config capabilities` already reports at runtime. This PR brings the three over-budget descriptions under 200 chars and adds a guard so new ones cannot regress.

## Changes

| Skill | description before | after | index entry before | after |
| --- | --- | --- | --- | --- |
| aionui-config | 666 | **194** | 687 | 215 |
| skill-creator | 226 | **186** | 247 | 207 |
| officecli | 222 | **194** | 239 | 211 |
| cron | 121 | unchanged | 133 | 133 |
| session-message | 119 | unchanged | 142 | 142 |
| **index entries total** | | | **1453** | **908** |

Every description keeps the hooks an agent matches user intent against: what the skill configures or does, which CLI it drives, and when to use it. What was dropped is the enumeration of operation verbs, the second restatement of the same trigger inside `Use when ...`, and behavioural contracts that belong in the skill body and are already documented there.

All three are now single-line plain scalars instead of `>-` block scalars, consistent with the other auto-inject skills.

New guard `auto_inject_skill_descriptions_stay_within_injection_budget` walks the embedded builtin corpus's `auto-inject/` entries and asserts each parsed description is at most 200 chars. It measures the parsed frontmatter value — what actually gets injected — rather than the raw YAML text.

No migration needed: startup sync upserts builtin descriptions into the `skills` table, so the new text propagates on the first launch after the corpus fingerprint changes.

## Verification

Automated:

- `cargo test -p aionui-extension` — all green
- `cargo test -p aionui-app --test config_cli_e2e --test skills_builtin_e2e` — all green; the static SKILL.md body assertions are unaffected since only frontmatter changed
- `cargo clippy -p aionui-extension --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Guard test red/green: with the three descriptions reverted it fails and reports 666 / 222 / 226; with them applied it passes

Dev build run-through, covering both skill delivery modes:

1. The built binary embeds only the new text; the old text is absent.
2. Startup re-materialized the builtin corpus purely because the corpus fingerprint changed — no version bump was involved.
3. The materialized on-disk tree and the `skills` table rows both report the new lengths.
4. Native-skills backends, where skills are symlinked into the conversation workspace: the linked SKILL.md files carry the new descriptions, and the prompt contains no skills index — the expected light-mode behaviour for that delivery path.
5. Injected-index backend: the first-message `## Available Skills` block measures 1004 chars, down from 1544, with all five entries showing the new text.

## Test plan

- [x] Unit and integration tests for the affected crates
- [x] Lint and format gates
- [x] Guard test fails on an over-budget description
- [x] Dev verification of native-skills delivery
- [x] Dev verification of injected-index delivery
- [ ] Reviewer sanity check: each shortened description still reads clearly on its own in the skills list UI, which renders the same string

## Out of scope

The `aioncore config capabilities` contract is hand-maintained and has no completeness assertion against the command tree. That is the more likely source of future drift and is left to a separate change.
