### PR TITLE
chore(acp): bump codebuddy and dimcode registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.137.1"
+      "version": "2.138.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.18"
+      "version": "0.3.19"
     },
     "dirac": {
       "registry_json_id": "dirac",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.137.1",
+                "@tencent-ai/codebuddy-code@2.138.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #921, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.137.1 → **2.138.0** | ok (protocolVersion 1) | auth required (`-32000`, category `auth`) |
| dimcode | `dimcode` | 0.3.18 → **0.3.19** | ok (agentInfo version 0.3.19) | auth required (`-32000`, "Provider credentials are required") |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials. codebuddy's `--acp` entrypoint is unchanged across the minor bump.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.137.1` → `2.138.0`. This is the same assertion that broke CI in #909 when a package-name regex missed it; the per-version scan introduced afterwards (grep each OUTGOING version across `crates/**/*.rs`) caught it before push this time. dimcode's `0.3.18` has no such assertion. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions, and changing them would break their hash expectations.

The other 9 Registry-pinned packages (autohand, deepagents, dirac, glm-acp-agent, grok, kilo, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

dimcode continues to self-report `agentInfo.title` as "DimAgent" against a public listing that says "DimCode" — the standing observation since #814; no metadata change.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.24-06dfed0`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.24-06dfed0/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the 39-id baseline (which includes `antigravity-acp`, deferred as binary-only since 2026-08-21).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
