### PR TITLE
chore(cli-version): verify codex against 0.149.1

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -37,7 +37,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// on does complete turns and passes the suite, so the gate walks forward over
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
-pub const VERIFIED_CODEX_VERSION: &str = "0.149.0";
+pub const VERIFIED_CODEX_VERSION: &str = "0.149.1";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.19";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
@@ -456,10 +456,10 @@ mod tests {
 
     #[test]
     fn components_compare_numerically_not_lexically() {
-        // The bug a string compare would introduce: "0.149.0" < "0.99.0"
+        // The bug a string compare would introduce: "0.149.1" < "0.99.0"
         // lexically, but 149 > 99.
         assert_eq!(classify("0.99.0", VERIFIED_CODEX_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("0.149.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("0.149.2", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
     }
 
     #[test]
@@ -578,10 +578,10 @@ mod tests {
         // verified release is told nothing, and this breaks if a bump lands
         // without re-verifying against that exact binary.
         assert_eq!(
-            classify("codex-cli 0.149.0", VERIFIED_CODEX_VERSION),
+            classify("codex-cli 0.149.1", VERIFIED_CODEX_VERSION),
             VersionVerdict::Verified
         );
-        assert!(drift_notice("codex", "codex-cli 0.149.0", VERIFIED_CODEX_VERSION).is_none());
+        assert!(drift_notice("codex", "codex-cli 0.149.1", VERIFIED_CODEX_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Moves `VERIFIED_CODEX_VERSION` from 0.149.0 to 0.149.1.

| Gate | Result |
| --- | --- |
| A — contract | **PASS** — 401 → 401 schema files, `+0 -0 ~0` after canonicalization; no method, no enum value touched |
| B — live e2e | **PASS 11/11**, 321.63s |
| C — release notes | **CLEAR** — but the release body is empty, so the range was triaged from the compare instead (below) |

## Zero release notes is not a pass on its own

`release_notes.py` returned `CLEAR (1 releases, 0 notes)`. The standing rule is that a gate which could not run is not a gate that passed, so the emptiness was checked rather than accepted. The release body is 105 characters — a heading and a compare link, no itemised notes. The compare *is* the content, so it was triaged from there: **5 commits, 23 files**.

- `Allow exec callers to classify new threads (#40161)`
- `Budget retained images during remote compaction (#40280)`
- `Identify detached memory requests as memory consolidation (#40186)`
- `Adapt image compaction backport for pre-annotation releases`

**Off our surface:** everything under `codex-rs/exec/` and `sdk/typescript/`. This repo spawns `codex app-server --stdio` and never `codex exec` (`codex_conn.rs:66`), so the exec CLI and SDK changes cannot reach us.

**On our surface, and unmoved:** the rest is core remote-compaction and context-manager work. Gate A is the check for that and it came back byte-identical — an internal compaction change that leaves the wire contract untouched is not observable from here.

## A schema changed that gate A does not cover

`codex-rs/core/config.schema.json` was modified. That is the **config-file** schema, a different document from the app-server protocol schema gate A diffs, so it would have gone unexamined if the empty notes had been taken at face value. The change is purely additive:

```diff
             "collaboration_modes": { "type": "boolean" },
+            "compaction_image_budget": { "type": "boolean" },
             "computer_use": { "type": "boolean" },
```

One new boolean feature flag, in two places. Nothing removed or renamed, and we do not set it.

## The candidate is proven from the suite log

```
direct CLI version detected session_id=26779425 cli=codex version=codex-cli 0.149.1
direct CLI version drift    session_id=26779425 cli=codex version=codex-cli 0.149.1
```

All 11 sessions report the candidate, each with a drift line that only appears because the binary disagrees with the not-yet-bumped constant.

## Tests

Three pinned fixtures re-pointed above the new constant rather than loosened; the literal verified-release assertion now names `codex-cli 0.149.1`. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/codex-cli/0.149.1/`

Constants and record only — no source change.