### PR TITLE
chore(acp): bump codebuddy, dimcode, glm and grok registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.138.0"
+      "version": "2.139.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.19"
+      "version": "0.3.20"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -29,12 +29,12 @@
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.8"
+      "version": "1.0.10"
     },
     "kilo": {
       "registry_json_id": "kilo",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.138.0",
+                "@tencent-ai/codebuddy-code@2.139.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #931, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.138.0 → **2.139.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.19 → **0.3.20** | ok (agentInfo version 0.3.20) | auth required (`-32000`, "Provider credentials are required") |
| glm-acp-agent | `glm-acp-agent` | 1.6.0 → **1.6.1** | ok (protocolVersion 1) | **succeeded** unauthenticated |
| grok | `@xai-official/grok` | 1.0.8 → **1.0.10** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |

All four meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

glm-acp-agent's session opened without auth and advertised `thought_level`, `mode`, and `model` option categories, including a `bypass_permissions` mode value. That is recorded as probe evidence only — this PR changes no metadata, so no `yolo_id` or mode data is derived from it. It also continues to self-report `agentInfo.version` as `1.0.0` while the package is 1.6.1; a standing vendor quirk, not an AionCore defect.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.138.0` → `2.139.0`. Every outgoing version (`2.138.0`, `0.3.19`, `1.6.0`, `1.0.8`) was grepped across `crates/**/*.rs` before committing; codebuddy's was the only real assertion, and the remaining textual matches are unrelated (a codex sample path, a Windows socket error code). `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions, and changing them would break their hash expectations.

The other 7 Registry-pinned packages (autohand, deepagents, dirac, kilo, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.25-fbfe844`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.25-fbfe844/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
