### PR TITLE
chore(cli-version): verify codex 0.150.1 and agy 1.1.22

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -37,8 +37,8 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// on does complete turns and passes the suite, so the gate walks forward over
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
-pub const VERIFIED_CODEX_VERSION: &str = "0.149.1";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.20";
+pub const VERIFIED_CODEX_VERSION: &str = "0.150.1";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.22";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -456,10 +456,10 @@ mod tests {
 
     #[test]
     fn components_compare_numerically_not_lexically() {
-        // The bug a string compare would introduce: "0.149.1" < "0.99.0"
-        // lexically, but 149 > 99.
+        // The bug a string compare would introduce: "0.150.1" < "0.99.0"
+        // lexically, but 150 > 99.
         assert_eq!(classify("0.99.0", VERIFIED_CODEX_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("0.149.2", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("0.150.2", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
     }
 
     #[test]
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.20", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.20", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.22", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.22", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.19", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.21", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.21", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet
@@ -568,9 +568,9 @@ mod tests {
     fn local_codex_output_is_classified_as_newer() {
         // Real `codex --version` output shape, one release above the verified
         // one so the newer path is what gets exercised.
-        assert_eq!(parse_version("codex-cli 0.150.0"), Some(vec![0, 150, 0]));
-        let (level, _, localized) = drift_notice("codex", "codex-cli 0.150.0", VERIFIED_CODEX_VERSION)
-            .expect("0.150.0 drifts from the verified release");
+        assert_eq!(parse_version("codex-cli 0.151.0"), Some(vec![0, 151, 0]));
+        let (level, _, localized) = drift_notice("codex", "codex-cli 0.151.0", VERIFIED_CODEX_VERSION)
+            .expect("0.151.0 drifts from the verified release");
         assert_eq!(level, NoticeLevel::Info);
         assert_eq!(localized.code, CODE_CLI_VERSION_NEWER);
 
@@ -578,10 +578,10 @@ mod tests {
         // verified release is told nothing, and this breaks if a bump lands
         // without re-verifying against that exact binary.
         assert_eq!(
-            classify("codex-cli 0.149.1", VERIFIED_CODEX_VERSION),
+            classify("codex-cli 0.150.1", VERIFIED_CODEX_VERSION),
             VersionVerdict::Verified
         );
-        assert!(drift_notice("codex", "codex-cli 0.149.1", VERIFIED_CODEX_VERSION).is_none());
+        assert!(drift_notice("codex", "codex-cli 0.150.1", VERIFIED_CODEX_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Two candidates, both through their gates against the real binaries.

| CLI | from → to | Gate A | Gate B | Gate C |
| --- | --- | --- | --- | --- |
| codex | 0.149.1 → **0.150.1** | **PASS** — 401 → 411 files, `ServerNotification` 75 → 79, `ClientRequest` 150 → 153, nothing removed | **PASS 11/11**, 679.80s | **CLEAR** — 220 notes over 2 releases, 0 REVIEW |
| agy | 1.1.20 → **1.1.22** | DEGRADED (no protocol schema) | **PASS 7/7**, 161.88s | **CLEAR** |

Both suites prove the candidate from their own logs — `version=codex-cli 0.150.1` and `version=1.1.22`, each with the drift lines that only appear because the binary disagrees with the not-yet-bumped constant. codex ran through an npm PATH shim; agy from a manifest download whose sha512 was checked before it executed. Neither of the operator’s installed CLIs was touched.

## agy: everything on our surface is a fix in our favour

- **"Fixed sessions stalling mid-response when a tool result or file diff contained invalid UTF-8."** (1.1.21) — a stall is a hung turn for our user, and print-mode sessions are what we run.
- **"Fixed transient HTTP 502 Bad Gateway errors terminating runs by adding automatic retry handling with backoff."** (1.1.22) — a terminated run reaches us as a failed turn.
- **"Fixed corrupted file edits in documents containing non-ASCII text… producing invalid UTF-8."** (1.1.21) — same family as the U+FFFD delta corruption #888 works around, different surface.
- **"Fixed file writes being reported as failures after successfully saving to disk."** (1.1.21)

None changes a contract; each removes a way a turn could look broken.

**The one permission item does not reach us.** 1.1.21 improved the `always-proceed` mode to auto-approve MCP tool calls, but `build_argv` sends `--mode` only for `accept-edits` and `plan` and opens the gate with `--dangerously-skip-permissions` (`argv.rs:76,107`), gating each call in AionUi’s own PreToolUse hook bridge. *Stated limit:* gate B does not exercise that bridge — its only permission test is claude’s — so this rests on the argv we build, not on a live run.

`--help` and `models --help` are byte-identical 1.1.20 → 1.1.22, diffed against the 08-26 capture rather than by re-running the 1.1.20 binary, which would have self-updated it and destroyed the control.

## agy gate C came from the web page this time, and that is the news

Three days ago the web changelog was frozen at 1.1.17 while the binary’s bundled `agy changelog` covered 1.1.19, so gate C switched to reading the binary. **Tonight it is the other way round.** The 1.1.22 build is genuine (size 179,586,688 vs 1.1.20’s 179,469,984) and its bundled changelog **stops at 1.1.20** — no 1.1.21, no 1.1.22 — while the web page has un-frozen and carries both.

The bundled copy is a snapshot from whenever that build was cut, not a live document. Neither source is authoritative; both are checked from now on, and the record says which one was used.

## codex

Gate A grew by 10 schema files and removed nothing. The only note flagged in 220 was `Preserve sandbox errors during session initialization` (#40381), which is additive error preservation. 0.147.0 remains deliberately skipped.

## Tests

Pinned fixtures for both CLIs moved with their constants — re-pointed above the new values rather than loosened, and both literal verified-release assertions now name the new releases. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

## Follow-up, not included here

agy 1.1.21 now generates conversation titles automatically. Whether it surfaces one on the print-mode wire, and whether we should consume it instead of generating our own, is **not investigated** — a capability question, and any change would be a source PR. No existing PR or issue covers it (searched).

Records: `~/aion/protocols/samples/codex-cli/0.150.1/` and `~/aion/protocols/samples/antigravity-cli/1.1.22/`

Constants and records only — no source change.