### PR TITLE
chore(acp): bump codebuddy and dimcode registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.140.0"
+      "version": "2.141.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.21"
+      "version": "0.3.22"
     },
     "dirac": {
       "registry_json_id": "dirac",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.140.0",
+                "@tencent-ai/codebuddy-code@2.141.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #941, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.140.0 → **2.141.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.21 → **0.3.22** | ok (agentInfo version 0.3.22) | auth required (`-32000`, "Provider credentials are required") |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials, and both entrypoints (`--acp` for codebuddy, `acp` for dimcode) are unchanged from the previous snapshot.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.140.0` → `2.141.0`. Both outgoing versions were grepped across `crates/**/*.rs` before staging: codebuddy's was the only real assertion, and `0.3.21`'s single hit was a false positive (a `"003421"` string literal in `pairing.rs`, matched because `.` is a regex wildcard). `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions, and changing them would break their hash expectations.

The other 9 Registry-pinned packages (autohand, deepagents, dirac, glm-acp-agent, grok, kilo, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

dimcode continues to self-report `agentInfo.title` as "DimAgent" against a public listing that says "DimCode" — a standing observation since #814; no metadata change.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.28-e9b1b2d`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.28-e9b1b2d/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
