### PR TITLE
chore(cli-version): verify claude against 2.1.236

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -36,7 +36,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// back-to-back control after three clean versions). Every release from 0.148.0
 /// on does complete turns and passes the suite, so the gate walks forward over
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.150.1";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.22";
 
@@ -450,8 +450,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.235", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.235", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.236", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.236", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Moves `VERIFIED_CLAUDE_VERSION` from 2.1.235 to 2.1.236, and **discharges the hold placed on 2026-08-21**.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — claude publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 14/14**, 304.35s |
| C — release notes | **CLEAR** — 33 notes, 0 REVIEW |

## Why this one was stuck

The constant has been sitting **above** the stable channel for eight days. An earlier version of the detector read npm’s `latest` tag, which for `@anthropic-ai/claude-code` points at the bleeding edge rather than the release most users run, so 2.1.235 was qualified off the `next` channel. Once the detector was corrected to track `stable`, every nightly run reported `drift: behind`, and the standing decision was to hold the floor rather than walk it down — walking it down would have flagged the majority of users (who install via `npm` or the native installer, both ahead of stable) as `Newer`.

stable has now caught up and passed it, so the normal flow resumes:

```
stable: 2.1.236    next: 2.1.251    latest: 2.1.250
```

## The candidate is proven from the suite log

```
version=2.1.236 (Claude Code)
```

with the drift lines that only appear because the binary disagrees with the not-yet-bumped constant. Run through an npm PATH shim into a temp dir; `~/.local/bin/claude` was read before and after and did not move off 2.1.239.

## Gate C

Both flagged notes are usage-credits UI — a Fable 5 first-run prompt auto-selecting a fallback model under Remote Control, and a `/usage` spend row for Team and Enterprise members. Neither is a surface this repo drives.

## Also checked

The promotion condition this repo does not machine-check: `THINKING_DISPLAY_MIN_VERSION` is `2.1.191` (`claude_flags.rs:34`), comfortably below the new constant. So nobody on exactly the verified release is told they match while thinking display is silently off.

## Tests

The literal verified-release assertion moves with the constant, so a future bump that forgets to re-verify still breaks the test. `cargo test -p aionui-session --lib cli_version`: 14/14. `cargo test -p aionui-ai-agent --lib claude_flags`: 5/5. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/claude-cli/2.1.236/`

Constants and record only — no source change.