### PR TITLE
fix(ai-agent): forward model-authored tool description from BackendOutputSink

### DIFF
--- a/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
@@ -52,6 +52,10 @@ impl OutputSink for BackendOutputSink {
         }
 
         let parsed_input = serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_owned()));
+        let description = parsed_input
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned);
 
         tracing::debug!(
             tool_use_id = %tool_use_id,
@@ -75,7 +79,7 @@ impl OutputSink for BackendOutputSink {
             status: ToolCallStatus::Running,
             input: Some(parsed_input),
             output: None,
-            description: None,
+            description,
             parent_call_id: None,
         }));
     }
@@ -329,6 +333,36 @@ mod tests {
                 assert_eq!(data.status, ToolCallStatus::Running);
                 assert!(data.input.is_some());
                 assert_eq!(data.input.unwrap()["pattern"], "**/*.rs");
+            }
+            other => panic!("Expected ToolCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn emit_tool_call_extracts_description_from_input() {
+        let (sink, mut rx) = make_sink();
+        sink.emit_tool_call(
+            "call_bash_1",
+            "ExecCommand",
+            r#"{"cmd":"cargo build","description":"Build the project"}"#,
+        );
+        let event = rx.try_recv().unwrap();
+        match event {
+            AgentStreamEvent::ToolCall(data) => {
+                assert_eq!(data.description.as_deref(), Some("Build the project"));
+            }
+            other => panic!("Expected ToolCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn emit_tool_call_without_description_keeps_none() {
+        let (sink, mut rx) = make_sink();
+        sink.emit_tool_call("call_bash_1", "ExecCommand", r#"{"cmd":"cargo build"}"#);
+        let event = rx.try_recv().unwrap();
+        match event {
+            AgentStreamEvent::ToolCall(data) => {
+                assert_eq!(data.description, None);
             }
             other => panic!("Expected ToolCall, got {:?}", other),
         }


### PR DESCRIPTION
## Summary

`BackendOutputSink` hardcoded `description: None` when forwarding aionrs
tool-call events to the frontend. A model-authored `description` therefore
never reached the renderer, and the tool-step label always fell back to the
raw command string.

## Changes

- Extract the optional `description` field from the parsed tool input in
  `emit_tool_call` and forward it through `ToolCallEventData` instead of `None`.
- Add two unit tests covering the description-present and description-absent
  paths.

## Testing

- New unit tests:
  - `emit_tool_call_extracts_description_from_input`
  - `emit_tool_call_without_description_keeps_none`
- Full workspace gate via `just push`:
  - `cargo nextest run --workspace`: **9131 passed**, 50 skipped
  - migration check, lint, fmt all green

## Related

Companion to the AionUi tool-execution rendering refactor — the frontend
already renders `description` when present, so this wires the backend side of
the same fix.
