### PR TITLE
chore: remove accidentally committed .opencode symlinks

### DIFF
--- a/.opencode/skills/cron
+++ b/.opencode/skills/cron
@@ -1,1 +1,0 @@
-/Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/cron

--- a/.opencode/skills/officecli
+++ b/.opencode/skills/officecli
@@ -1,1 +1,0 @@
-/Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/officecli

--- a/.opencode/skills/skill-creator
+++ b/.opencode/skills/skill-creator
@@ -1,1 +1,0 @@
-/Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/skill-creator


### PR DESCRIPTION
## What

Removes three tracked entries under `.opencode/skills/` that are symlinks
pointing to a contributor's personal machine path:

```
.opencode/skills/cron          -> /Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/cron
.opencode/skills/officecli     -> /Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/officecli
.opencode/skills/skill-creator -> /Users/zhoukai/.aionui-dev/builtin-skills/auto-inject/skill-creator
```

## Why

- These are broken on every checkout except the original author's machine — the
  targets live under `/Users/zhoukai/...`.
- `.opencode` is the opencode CLI's local working directory (same category as
  `.claude` / `.codex`). We do not use opencode routinely in this repo, so it is
  intentionally absent from `.gitignore` — just like `.codex`. Nothing to guard,
  no `.gitignore` change needed.
- They slipped in via #758 (`f0422ca2`), which was unrelated to `.opencode`.
  This is purely an accidental-commit cleanup.

## Scope

- `3 files changed, 3 deletions(-)` — symlink removals only, no code impact.
- Verified AionUi is clean (no `.opencode` tracked, no history), so no follow-up
  needed there.