### PR TITLE
feat(conversation): route @@ mentions to the session-message skill

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
@@ -36,12 +36,14 @@ When the user typed `@@`, their message carries a block like:
 
 ```
 [[AION_SESSIONS]]
+To deliver to the conversations below, use the session-message skill (address by conversation id).
 重构-鉴权模块	conv_019f…	workspace: same
-文档站改版	conv_01a0…	workspace: /Users/x/docs（与你不同）
+文档站改版	conv_01a0…	workspace: /Users/x/docs (differs from yours)
 [[/AION_SESSIONS]]
 ```
 
-Each line is `name`, tab, `id`, tab, `workspace:`. Use the **id**.
+The first line is a hint that this skill is how to deliver. Every following
+line is a target: `name`, tab, `id`, tab, `workspace:`. Use the **id**.
 
 ## Delivering a message
 
@@ -62,7 +64,7 @@ A delivered message arrives with this block at the top:
 [[AION_SESSION_MESSAGE]]
 from: 重构-鉴权模块	conv_019f…
 workspace: same
-reply_to: conv_019f…	（回信: session send-message, to=reply_to）
+reply_to: conv_019f…	(reply: session send-message, to=reply_to)
 [[/AION_SESSION_MESSAGE]]
 ```
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -9704,7 +9704,7 @@ mod session_mentions_integration {
             .unwrap();
 
         assert!(
-            resolved.contains("文档站改版\tconv_docs\tworkspace: /w/docs（与你不同）"),
+            resolved.contains("文档站改版\tconv_docs\tworkspace: /w/docs (differs from yours)"),
             "{resolved}"
         );
     }

--- a/crates/aionui-conversation/src/session_mentions.rs
+++ b/crates/aionui-conversation/src/session_mentions.rs
@@ -32,16 +32,44 @@ pub struct SessionMentionTargetInfo {
 pub fn workspace_field_value(sender_workspace: Option<&str>, target_workspace: Option<&str>) -> String {
     match (sender_workspace, target_workspace) {
         (Some(sender), Some(target)) if sender == target => "same".to_owned(),
-        (_, Some(target)) => format!("{target}（与你不同）"),
-        (_, None) => "unknown（与你不同）".to_owned(),
+        (_, Some(target)) => format!("{target} (differs from yours)"),
+        (_, None) => "unknown (differs from yours)".to_owned(),
     }
 }
 
-/// Build the sender-side block. Deliberately carries no usage instructions
-/// (spec §8.3): the trigger is the user typing `@@`, and the auto-inject skill
-/// is what must independently explain sending.
+/// The one routing hint the block carries: it names the skill to deliver with,
+/// and never a command template — the skill body stays the single source of the
+/// actual command (`send-message`), so the block and the skill cannot drift.
+///
+/// It is emitted as the FIRST in-marker line on purpose. The frontend's
+/// `parseSessionsBlock` (`sessionMarkers.ts`) renders only the text OUTSIDE the
+/// markers and turns each in-marker line into a chip only when it splits into
+/// `name \t id \t workspace`. This line has no tab, so it is dropped from the
+/// sender's bubble AND skipped by the chip parser — while every agent backend
+/// still receives it verbatim in the message content.
+///
+/// English on purpose. Everything between the markers is agent-facing: the
+/// frontend strips this whole block from the displayed text and re-renders the
+/// human-facing chips/labels separately (via i18n), so the block's own bytes are
+/// read only by the agent. The block is therefore written entirely in English —
+/// including the `workspace:` warning below — to match the `session-message`
+/// skill it routes to.
+const SESSIONS_BLOCK_SKILL_HINT: &str =
+    "To deliver to the conversations below, use the session-message skill (address by conversation id).";
+
+/// Build the sender-side block.
+///
+/// Spec §8.3 originally kept this block instruction-free and left sending to the
+/// auto-inject skill. That relied on the agent loading the skill's body before
+/// choosing how to deliver, which is not guaranteed: a competing built-in
+/// cross-session tool can be reached first, and in `Injected` skill-delivery
+/// mode the body is lazy-loaded. So the block now carries ONE positive routing
+/// hint ([`SESSIONS_BLOCK_SKILL_HINT`]) that points at the `session-message`
+/// skill — but still no command template, keeping §8.3's real invariant intact.
 pub fn build_sessions_block(sender_workspace: Option<&str>, targets: &[SessionMentionTargetInfo]) -> String {
     let mut block = String::from(AIONUI_SESSIONS_MARKER);
+    block.push('\n');
+    block.push_str(SESSIONS_BLOCK_SKILL_HINT);
     for target in targets {
         block.push('\n');
         block.push_str(&target.name);

--- a/crates/aionui-conversation/src/session_mentions_test.rs
+++ b/crates/aionui-conversation/src/session_mentions_test.rs
@@ -8,14 +8,17 @@ fn same_workspace_renders_the_literal_same() {
 #[test]
 fn different_workspace_renders_target_path_with_the_warning_copy() {
     let value = workspace_field_value(Some("/w/a"), Some("/w/b"));
-    assert_eq!(value, "/w/b（与你不同）");
+    assert_eq!(value, "/w/b (differs from yours)");
 }
 
 #[test]
 fn unknown_target_workspace_is_reported_as_unknown_not_as_same() {
     // A missing workspace must never collapse to `same`: that would tell the
     // agent relative paths are safe when we do not know that.
-    assert_eq!(workspace_field_value(Some("/w/a"), None), "unknown（与你不同）");
+    assert_eq!(
+        workspace_field_value(Some("/w/a"), None),
+        "unknown (differs from yours)"
+    );
 }
 
 #[test]
@@ -38,16 +41,43 @@ fn sessions_block_is_delimited_and_tab_separated_one_target_per_line() {
     assert_eq!(
         block,
         "[[AION_SESSIONS]]\n\
+         To deliver to the conversations below, use the session-message skill (address by conversation id).\n\
          重构-鉴权模块\tconv_1\tworkspace: same\n\
-         文档站改版\tconv_2\tworkspace: /w/docs（与你不同）\n\
+         文档站改版\tconv_2\tworkspace: /w/docs (differs from yours)\n\
          [[/AION_SESSIONS]]"
     );
 }
 
 #[test]
-fn sessions_block_carries_no_usage_instructions() {
-    // spec §8.3: the sender-side block deliberately carries no command
-    // template — the skill covers sending.
+fn sessions_block_routes_to_the_session_message_skill_on_its_first_line() {
+    // The routing hint must be the FIRST in-marker line and have no tab, so the
+    // frontend drops it from the sender's bubble and the chip parser skips it
+    // (see `build_sessions_block`). The agent still receives it in the content.
+    let block = build_sessions_block(
+        Some("/w/a"),
+        &[SessionMentionTargetInfo {
+            id: "conv_1".to_owned(),
+            name: "x".to_owned(),
+            workspace: Some("/w/a".to_owned()),
+        }],
+    );
+    let first_inner_line = block.lines().nth(1).expect("a line after the opening marker");
+    assert_eq!(
+        first_inner_line,
+        "To deliver to the conversations below, use the session-message skill (address by conversation id)."
+    );
+    assert!(
+        !first_inner_line.contains('\t'),
+        "the hint must not look like a target row: {first_inner_line}"
+    );
+}
+
+#[test]
+fn sessions_block_carries_no_command_template() {
+    // spec §8.3 (revised): the block now names the `session-message` skill (see
+    // `sessions_block_routes_to_the_session_message_skill_on_its_first_line`),
+    // but STILL carries no command template — the skill body owns the actual
+    // command, so the two cannot drift.
     let block = build_sessions_block(
         Some("/w/a"),
         &[SessionMentionTargetInfo {

--- a/crates/aionui-session-message/src/service.rs
+++ b/crates/aionui-session-message/src/service.rs
@@ -39,12 +39,16 @@ use crate::rate_limit::{RateLimiter, RateVerdict};
 /// The short reply pointer after `reply_to` is deliberate (~10-15 tokens): the
 /// recipient must know it can reply at all, or the reply path is dead. The full
 /// schema does not go here — that is what `session capabilities` is for.
+///
+/// The block is agent-facing — the frontend strips it and renders human-facing
+/// labels separately via i18n — so its text (the reply pointer and the
+/// `workspace:` warning) is written in English, not localized.
 pub fn build_session_message_block(from_name: &str, from_id: &str, workspace_field: &str, reply_to: &str) -> String {
     format!(
         "{AIONUI_SESSION_MESSAGE_MARKER}\n\
          from: {from_name}\t{from_id}\n\
          workspace: {workspace_field}\n\
-         reply_to: {reply_to}\t（回信: session send-message, to=reply_to）\n\
+         reply_to: {reply_to}\t(reply: session send-message, to=reply_to)\n\
          {AIONUI_SESSION_MESSAGE_END_MARKER}"
     )
 }
@@ -63,8 +67,8 @@ pub fn compose_delivery_content(block: &str, message: &str) -> String {
 fn recipient_workspace_field(sender_workspace: Option<&str>, target_workspace: Option<&str>) -> String {
     match (sender_workspace, target_workspace) {
         (Some(sender), Some(target)) if sender == target => "same".to_owned(),
-        (Some(sender), _) => format!("{sender}（与你不同，勿用相对路径，勿假设可读）"),
-        (None, _) => "unknown（与你不同，勿用相对路径，勿假设可读）".to_owned(),
+        (Some(sender), _) => format!("{sender} (differs from yours; don't use relative paths, don't assume readable)"),
+        (None, _) => "unknown (differs from yours; don't use relative paths, don't assume readable)".to_owned(),
     }
 }
 

--- a/crates/aionui-session-message/src/service_test.rs
+++ b/crates/aionui-session-message/src/service_test.rs
@@ -8,7 +8,7 @@ fn same_workspace_block_matches_the_spec_shape_exactly() {
         "[[AION_SESSION_MESSAGE]]\n\
          from: 重构-鉴权模块\tconv_1\n\
          workspace: same\n\
-         reply_to: conv_1\t（回信: session send-message, to=reply_to）\n\
+         reply_to: conv_1\t(reply: session send-message, to=reply_to)\n\
          [[/AION_SESSION_MESSAGE]]"
     );
 }
@@ -18,11 +18,13 @@ fn cross_workspace_block_carries_the_constraint_inside_the_field_value() {
     let block = build_session_message_block(
         "A",
         "conv_1",
-        "/Users/x/proj-a（与你不同，勿用相对路径，勿假设可读）",
+        "/Users/x/proj-a (differs from yours; don't use relative paths, don't assume readable)",
         "conv_1",
     );
     assert!(
-        block.contains("workspace: /Users/x/proj-a（与你不同，勿用相对路径，勿假设可读）"),
+        block.contains(
+            "workspace: /Users/x/proj-a (differs from yours; don't use relative paths, don't assume readable)"
+        ),
         "{block}"
     );
 }
@@ -53,7 +55,7 @@ fn the_recipient_workspace_field_says_same_only_when_both_sides_match() {
     assert_eq!(recipient_workspace_field(Some("/w/a"), Some("/w/a")), "same");
     assert_eq!(
         recipient_workspace_field(Some("/w/a"), Some("/w/b")),
-        "/w/a（与你不同，勿用相对路径，勿假设可读）"
+        "/w/a (differs from yours; don't use relative paths, don't assume readable)"
     );
 }
 
@@ -63,7 +65,7 @@ fn an_unknown_sender_workspace_never_collapses_to_same() {
     // relative paths are safe when we do not know that.
     let value = recipient_workspace_field(None, Some("/w/b"));
     assert!(value.starts_with("unknown"), "{value}");
-    assert!(value.contains("勿用相对路径"), "{value}");
+    assert!(value.contains("don't use relative paths"), "{value}");
 
     let both_unknown = recipient_workspace_field(None, None);
     assert!(both_unknown.starts_with("unknown"), "{both_unknown}");
@@ -74,7 +76,10 @@ fn a_known_sender_workspace_with_an_unknown_target_is_reported_as_different() {
     // The recipient block states the SENDER's path, so it stays usable even
     // when the target row records no workspace.
     let value = recipient_workspace_field(Some("/w/a"), None);
-    assert_eq!(value, "/w/a（与你不同，勿用相对路径，勿假设可读）");
+    assert_eq!(
+        value,
+        "/w/a (differs from yours; don't use relative paths, don't assume readable)"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-session-message/tests/delivery_semantics.rs
+++ b/crates/aionui-session-message/tests/delivery_semantics.rs
@@ -246,7 +246,7 @@ async fn a_cross_workspace_delivery_states_the_absolute_path_and_the_constraint(
 
     let content = ctx.last_user_message_content("conv_target").await;
     assert!(
-        content.contains("workspace: /w/a（与你不同，勿用相对路径，勿假设可读）"),
+        content.contains("workspace: /w/a (differs from yours; don't use relative paths, don't assume readable)"),
         "{content}"
     );
 }


### PR DESCRIPTION
## What & why

Cross-session delivery could pick the wrong mechanism. The `[[AION_SESSIONS]]` block that a `@@` mention appends to the user's message deliberately carried no usage instructions, on the assumption the agent would load the `session-message` skill before deciding how to deliver. That assumption does not hold: a competing built-in cross-session tool can be reached first, and in `Injected` skill-delivery mode the skill body is lazy-loaded, so at tool-selection time the routing guidance is not present. The result was delivery attempts through the wrong tool until the skill was named explicitly.

## Change

- Emit one positive routing hint as the **first in-marker line** of the `[[AION_SESSIONS]]` block, naming the `session-message` skill (address by conversation id). It carries **no command template** — the skill body stays the single source of the actual command, so the block and the skill cannot drift. The hint has no tab, so the frontend drops it from the sender's bubble and the chip parser skips it, while every agent backend still receives it in the message content.
- Write the block's remaining **agent-facing** text in English, since these bytes are read by the agent (the frontend strips the block and renders human-facing labels separately via i18n): the sender-side and recipient-side cross-workspace warnings and the reply pointer. This keeps the whole block single-language and portable across agents.
- Update the skill doc example and the affected unit tests; add comments recording that in-block text is agent-facing and therefore English.

## Verification (dev environment)

Exercised real `@@` cross-session sends and replies in the dev app, then inspected the stored messages, the prompt dumps fed to each agent, and the structured logs. Confirmed (local-only details omitted):

- The routing hint is emitted as the first in-marker line and reaches the agent's actual input.
- Across all four agent backends (**codex, claude, opencode, aionrs**), senders routed to the `session-message` skill and deliveries were accepted, with no failures (no unreachable-target / reject / rate-limit).
- Both skill-delivery modes were covered: **native (Argv)** — invoked via the Skill tool; **injected** — skill body fetched via the `skills show` channel.
- The English recipient-block text (cross-workspace warning, reply pointer) appears in the delivered content, while the UI shows the localized "different workspace" label; the hint and warning do not leak into visible bubble text.

## Test plan

- [x] `cargo test -p aionui-conversation -p aionui-session-message`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-conversation -p aionui-session-message -- -D warnings`
- [x] Full workspace pre-push gate via `just push`
