### PR TITLE
feat(session-message): add session capabilities fallback to @@ blocks

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
@@ -36,14 +36,15 @@ When the user typed `@@`, their message carries a block like:
 
 ```
 [[AION_SESSIONS]]
-To deliver to the conversations below, use the session-message skill (address by conversation id).
+To deliver to the conversations below, use the session-message skill (address by conversation id); if it is unavailable, run `"$AIONUI_HELPER_BIN" session capabilities` for the delivery contract.
 重构-鉴权模块	conv_019f…	workspace: same
 文档站改版	conv_01a0…	workspace: /Users/x/docs (differs from yours)
 [[/AION_SESSIONS]]
 ```
 
-The first line is a hint that this skill is how to deliver. Every following
-line is a target: `name`, tab, `id`, tab, `workspace:`. Use the **id**.
+The first line is a hint that this skill is how to deliver, with a fallback to
+`session capabilities` when the skill is unavailable. Every following line is a
+target: `name`, tab, `id`, tab, `workspace:`. Use the **id**.
 
 ## Delivering a message
 
@@ -65,6 +66,7 @@ A delivered message arrives with this block at the top:
 from: 重构-鉴权模块	conv_019f…
 workspace: same
 reply_to: conv_019f…	(reply: session send-message, to=reply_to)
+For the full delivery contract, run `"$AIONUI_HELPER_BIN" session capabilities`.
 [[/AION_SESSION_MESSAGE]]
 ```
 

--- a/crates/aionui-app/tests/session_skill.rs
+++ b/crates/aionui-app/tests/session_skill.rs
@@ -100,16 +100,24 @@ fn the_skill_states_the_non_negotiable_rules() {
 #[test]
 fn the_skill_points_at_capabilities_only_as_a_fallback() {
     let body = skill_body();
-    let capabilities_at = body
-        .find("session capabilities")
-        .expect("the skill must name the capabilities fallback");
+    // Anchor on the runnable, copyable commands (start-of-line inside a ```bash
+    // fence), not on bare substrings. The quoted `[[AION_SESSIONS]]` /
+    // `[[AION_SESSION_MESSAGE]]` example blocks now mention `session capabilities`
+    // inline as a CONDITIONAL fallback ("if it is unavailable, run ..."), which is
+    // exactly the framing this guard is named for — a hint, not a command to copy.
+    // §8.5 only cares that the copyable SEND command precedes the copyable
+    // CAPABILITIES command, and their order is unchanged (send still first), so
+    // the agent never needs a round trip to send its first message.
     let send_at = body
-        .find("session send-message")
-        .expect("the skill must document sending");
+        .find("\n\"$AIONUI_HELPER_BIN\" session send-message")
+        .expect("the skill must carry a copyable send command");
+    let capabilities_at = body
+        .find("\n\"$AIONUI_HELPER_BIN\" session capabilities")
+        .expect("the skill must carry a copyable capabilities fallback command");
     assert!(
         send_at < capabilities_at,
-        "the copyable send example must come before the capabilities fallback, \
-         so the agent never needs a round trip to send its first message"
+        "the copyable send command must come before the copyable capabilities \
+         fallback, so the agent never needs a round trip to send its first message"
     );
 }
 

--- a/crates/aionui-conversation/src/session_mentions.rs
+++ b/crates/aionui-conversation/src/session_mentions.rs
@@ -37,9 +37,14 @@ pub fn workspace_field_value(sender_workspace: Option<&str>, target_workspace: O
     }
 }
 
-/// The one routing hint the block carries: it names the skill to deliver with,
-/// and never a command template — the skill body stays the single source of the
-/// actual command (`send-message`), so the block and the skill cannot drift.
+/// The one routing hint the block carries: it names the `session-message` skill
+/// to deliver with, and adds an UNCONDITIONAL `session capabilities` fallback for
+/// when that skill is unavailable (the user can uncheck the auto-inject skill in
+/// the assistant editor). It still carries no `send-message` payload command
+/// template — the skill body stays the single source of that payload shape, so
+/// the block and the skill cannot drift. `session capabilities` is different: it
+/// is a self-describing, descriptor-generated discovery command (not a payload
+/// template), so pointing at it introduces nothing that can drift.
 ///
 /// It is emitted as the FIRST in-marker line on purpose. The frontend's
 /// `parseSessionsBlock` (`sessionMarkers.ts`) renders only the text OUTSIDE the
@@ -54,18 +59,20 @@ pub fn workspace_field_value(sender_workspace: Option<&str>, target_workspace: O
 /// read only by the agent. The block is therefore written entirely in English —
 /// including the `workspace:` warning below — to match the `session-message`
 /// skill it routes to.
-const SESSIONS_BLOCK_SKILL_HINT: &str =
-    "To deliver to the conversations below, use the session-message skill (address by conversation id).";
+const SESSIONS_BLOCK_SKILL_HINT: &str = "To deliver to the conversations below, use the session-message skill (address by conversation id); if it is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the delivery contract.";
 
 /// Build the sender-side block.
 ///
-/// Spec §8.3 originally kept this block instruction-free and left sending to the
-/// auto-inject skill. That relied on the agent loading the skill's body before
-/// choosing how to deliver, which is not guaranteed: a competing built-in
-/// cross-session tool can be reached first, and in `Injected` skill-delivery
-/// mode the body is lazy-loaded. So the block now carries ONE positive routing
-/// hint ([`SESSIONS_BLOCK_SKILL_HINT`]) that points at the `session-message`
-/// skill — but still no command template, keeping §8.3's real invariant intact.
+/// The block is agent-facing and written in English. Spec §8.3 originally kept it
+/// instruction-free and left sending to the auto-inject skill. That relied on the
+/// agent loading the skill's body before choosing how to deliver, which is not
+/// guaranteed: a competing built-in cross-session tool can be reached first, in
+/// `Injected` skill-delivery mode the body is lazy-loaded, and the user can
+/// uncheck the skill entirely. So the block now carries ONE routing hint
+/// ([`SESSIONS_BLOCK_SKILL_HINT`]) that names the `session-message` skill and
+/// adds an unconditional `session capabilities` fallback for when it is
+/// unavailable — but still no `send-message` payload command template, keeping
+/// §8.3's real invariant (the payload shape lives only in the skill body) intact.
 pub fn build_sessions_block(sender_workspace: Option<&str>, targets: &[SessionMentionTargetInfo]) -> String {
     let mut block = String::from(AIONUI_SESSIONS_MARKER);
     block.push('\n');

--- a/crates/aionui-conversation/src/session_mentions_test.rs
+++ b/crates/aionui-conversation/src/session_mentions_test.rs
@@ -41,7 +41,7 @@ fn sessions_block_is_delimited_and_tab_separated_one_target_per_line() {
     assert_eq!(
         block,
         "[[AION_SESSIONS]]\n\
-         To deliver to the conversations below, use the session-message skill (address by conversation id).\n\
+         To deliver to the conversations below, use the session-message skill (address by conversation id); if it is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the delivery contract.\n\
          重构-鉴权模块\tconv_1\tworkspace: same\n\
          文档站改版\tconv_2\tworkspace: /w/docs (differs from yours)\n\
          [[/AION_SESSIONS]]"
@@ -64,7 +64,7 @@ fn sessions_block_routes_to_the_session_message_skill_on_its_first_line() {
     let first_inner_line = block.lines().nth(1).expect("a line after the opening marker");
     assert_eq!(
         first_inner_line,
-        "To deliver to the conversations below, use the session-message skill (address by conversation id)."
+        "To deliver to the conversations below, use the session-message skill (address by conversation id); if it is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the delivery contract."
     );
     assert!(
         !first_inner_line.contains('\t'),
@@ -73,11 +73,15 @@ fn sessions_block_routes_to_the_session_message_skill_on_its_first_line() {
 }
 
 #[test]
-fn sessions_block_carries_no_command_template() {
-    // spec §8.3 (revised): the block now names the `session-message` skill (see
-    // `sessions_block_routes_to_the_session_message_skill_on_its_first_line`),
-    // but STILL carries no command template — the skill body owns the actual
-    // command, so the two cannot drift.
+fn sessions_block_carries_the_capabilities_fallback_but_no_send_message_payload_template() {
+    // spec §8.3 (revised): the block names the `session-message` skill (see
+    // `sessions_block_routes_to_the_session_message_skill_on_its_first_line`) and
+    // now carries an unconditional `session capabilities` fallback for when that
+    // skill is unavailable. The convergence invariant is narrower than "no
+    // command at all": what must never appear is a `send-message` PAYLOAD command
+    // template (that is the shape that would drift from the skill body). A pointer
+    // to the self-describing, descriptor-generated `session capabilities`
+    // discovery command is explicitly allowed — it cannot drift.
     let block = build_sessions_block(
         Some("/w/a"),
         &[SessionMentionTargetInfo {
@@ -86,8 +90,11 @@ fn sessions_block_carries_no_command_template() {
             workspace: Some("/w/a".to_owned()),
         }],
     );
+    // Still no `send-message` payload template — the skill body owns that shape.
     assert!(!block.contains("send-message"), "{block}");
-    assert!(!block.contains("AIONUI_HELPER_BIN"), "{block}");
+    // But the capabilities discovery pointer IS present.
+    assert!(block.contains("session capabilities"), "{block}");
+    assert!(block.contains("$AIONUI_HELPER_BIN"), "{block}");
 }
 
 #[test]

--- a/crates/aionui-session-message/src/service.rs
+++ b/crates/aionui-session-message/src/service.rs
@@ -38,17 +38,27 @@ use crate::rate_limit::{RateLimiter, RateVerdict};
 ///
 /// The short reply pointer after `reply_to` is deliberate (~10-15 tokens): the
 /// recipient must know it can reply at all, or the reply path is dead. The full
-/// schema does not go here — that is what `session capabilities` is for.
+/// schema does not go here — that is what `session capabilities` is for, so the
+/// block closes with an unconditional pointer to it: even when the
+/// `session-message` skill is unchecked, the recipient can still fetch the whole
+/// delivery contract. It carries no `send-message` payload command template — the
+/// skill body stays the single source of that payload shape.
+///
+/// The trailing `session capabilities` line has no `from:`/`workspace:`/`reply_to:`
+/// prefix, so the frontend's `parseSessionMessageBlock` (`sessionMarkers.ts`)
+/// ignores it; the whole block is stripped from the bubble regardless, so it is
+/// UI-safe and never breaks the `reply_to` address parse (which splits on `\t`).
 ///
 /// The block is agent-facing — the frontend strips it and renders human-facing
-/// labels separately via i18n — so its text (the reply pointer and the
-/// `workspace:` warning) is written in English, not localized.
+/// labels separately via i18n — so its text (the reply pointer, the `workspace:`
+/// warning, and the capabilities pointer) is written in English, not localized.
 pub fn build_session_message_block(from_name: &str, from_id: &str, workspace_field: &str, reply_to: &str) -> String {
     format!(
         "{AIONUI_SESSION_MESSAGE_MARKER}\n\
          from: {from_name}\t{from_id}\n\
          workspace: {workspace_field}\n\
          reply_to: {reply_to}\t(reply: session send-message, to=reply_to)\n\
+         For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`.\n\
          {AIONUI_SESSION_MESSAGE_END_MARKER}"
     )
 }

--- a/crates/aionui-session-message/src/service_test.rs
+++ b/crates/aionui-session-message/src/service_test.rs
@@ -9,6 +9,7 @@ fn same_workspace_block_matches_the_spec_shape_exactly() {
          from: 重构-鉴权模块\tconv_1\n\
          workspace: same\n\
          reply_to: conv_1\t(reply: session send-message, to=reply_to)\n\
+         For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`.\n\
          [[/AION_SESSION_MESSAGE]]"
     );
 }
@@ -37,6 +38,34 @@ fn the_block_always_states_how_to_reply() {
     let block = build_session_message_block("A", "conv_1", "same", "conv_1");
     assert!(block.contains("session send-message"), "{block}");
     assert!(block.contains("to=reply_to"), "{block}");
+}
+
+#[test]
+fn the_block_carries_an_unconditional_capabilities_fallback_without_breaking_reply_to() {
+    // Even when the `session-message` skill is unchecked, the recipient can fetch
+    // the whole contract. The pointer sits on its OWN line, so it neither matches
+    // the `reply_to:` prefix nor the `\t` the frontend splits the address on.
+    let block = build_session_message_block("A", "conv_1", "same", "conv_1");
+    assert!(
+        block.contains("For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`."),
+        "{block}"
+    );
+    let reply_line = block
+        .lines()
+        .find(|line| line.starts_with("reply_to: "))
+        .expect("a reply_to line");
+    assert!(
+        !reply_line.contains("session capabilities"),
+        "the capabilities pointer must not ride the reply_to line: {reply_line}"
+    );
+    // The address is the first tab-separated segment of the reply_to line, exactly
+    // as the frontend parses it — the new line must not perturb that.
+    assert_eq!(
+        reply_line
+            .strip_prefix("reply_to: ")
+            .and_then(|rest| rest.split('\t').next()),
+        Some("conv_1")
+    );
 }
 
 #[test]

--- a/crates/aionui-session-message/tests/delivery_semantics.rs
+++ b/crates/aionui-session-message/tests/delivery_semantics.rs
@@ -230,6 +230,12 @@ async fn an_idle_target_is_delivered_and_actually_starts_a_turn() {
     assert!(content.starts_with("[[AION_SESSION_MESSAGE]]"), "{content}");
     assert!(content.contains(&format!("reply_to: {}", from.id)), "{content}");
     assert!(content.contains("workspace: same"), "{content}");
+    // The delivered block carries the unconditional capabilities fallback, so a
+    // recipient with the skill unchecked can still fetch the full contract.
+    assert!(
+        content.contains("For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`."),
+        "{content}"
+    );
     assert!(content.trim_end().ends_with("接口定完了吗？"), "{content}");
 }
 


### PR DESCRIPTION
## Summary

Follow-up robustness hardening for the merged `@@` cross-session delivery work (#949).

The `session-message` auto-inject skill can be unchecked by the user in the assistant editor. When it is, the routing hint in the sender block (`[[AION_SESSIONS]]`) and the reply pointer in the recipient block (`[[AION_SESSION_MESSAGE]]`) lose their how-to — even though the `session send-message` CLI always exists. This adds one **unconditional** pointer to `session capabilities` in each block, so an agent can fetch the self-describing delivery contract and complete delivery even with the skill turned off. No "skill checked or not" branching is introduced — the fallback is always emitted.

`session capabilities` is a descriptor-generated, self-describing discovery command (not a payload template), so it cannot drift from the wired CLI. This keeps the original convergence invariant intact: the blocks still carry **no `send-message` payload command template**.

## What changed

- **Sender block** (`aionui-conversation/src/session_mentions.rs`): the routing hint now ends with a fallback pointing at `session capabilities` for the delivery contract.
- **Recipient block** (`aionui-session-message/src/service.rs`): a `session capabilities` pointer is appended on its own line before the end marker. It carries no `from:`/`workspace:`/`reply_to:` prefix and no tab, so the frontend parser ignores it and the `reply_to` address parse (which splits on the first tab) is unaffected.
- **Doc comments** updated on both block builders: agent-facing, English, capabilities fallback, still no `send-message` payload template.
- **Tests**: exact-shape and first-line assertions updated; the sender invariant test renamed and refocused (still forbids a `send-message` payload template, now asserts the capabilities pointer + `$AIONUI_HELPER_BIN` are present); a new recipient test asserts the capabilities line does not break `reply_to` parsing; the delivery happy-path integration test asserts the pointer reaches the delivered content.
- **`session_skill.rs` content guard**: `the_skill_points_at_capabilities_only_as_a_fallback` now anchors on the runnable, start-of-line commands (`session send-message` before `session capabilities`) instead of bare substrings — the example blocks legitimately quote `session capabilities` inline as a conditional fallback, which is exactly the framing this guard is named for. The test intent is unchanged; the check is more precise, not weaker.
- **`SKILL.md`** (builtin auto-inject skill): both example blocks and the surrounding prose synced to match the real emitted output.

## Runtime Verification

Verified by the automated suite and in a dev environment.

**Automated:** full pre-push gate green — migration-immutability check, workspace lint, format check, and the complete `cargo nextest` workspace suite (all tests passed).

**Dev environment:** exercised real `@@` sends/replies and inspected the stored messages and structured logs (local paths, conversation ids/names, and model names omitted here).

- Both blocks carry the `session capabilities` pointer in real deliveries, across all four agent backends (codex, claude, opencode, aionrs).
- **Skill-off scenario — the case this change targets:** with `session-message` disabled, a sender received the `@@` block, ran `session capabilities` from the pointer, fetched the self-describing contract (including the `send-message` input schema), and completed delivery end-to-end. A control group with the skill enabled delivered normally.
- All deliveries were accepted (`delivered`); no unreachable-target / reject / rate-limit failures.
- The recipient-block pointer sits on its own line and did not perturb `reply_to` address parsing.

## Notes

- `team` messaging is untouched: `team_send_message` is an MCP tool whose usage is fixed in the team system prompt and is unaffected by this skill toggle.
