### PR TITLE
fix(session-message): align recipient block capabilities wording with sender

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/session-message/SKILL.md
@@ -66,7 +66,7 @@ A delivered message arrives with this block at the top:
 from: 重构-鉴权模块	conv_019f…
 workspace: same
 reply_to: conv_019f…	(reply: session send-message, to=reply_to)
-For the full delivery contract, run `"$AIONUI_HELPER_BIN" session capabilities`.
+If the session-message skill is unavailable, run `"$AIONUI_HELPER_BIN" session capabilities` for the full delivery contract.
 [[/AION_SESSION_MESSAGE]]
 ```
 

--- a/crates/aionui-session-message/src/service.rs
+++ b/crates/aionui-session-message/src/service.rs
@@ -39,10 +39,11 @@ use crate::rate_limit::{RateLimiter, RateVerdict};
 /// The short reply pointer after `reply_to` is deliberate (~10-15 tokens): the
 /// recipient must know it can reply at all, or the reply path is dead. The full
 /// schema does not go here — that is what `session capabilities` is for, so the
-/// block closes with an unconditional pointer to it: even when the
-/// `session-message` skill is unchecked, the recipient can still fetch the whole
-/// delivery contract. It carries no `send-message` payload command template — the
-/// skill body stays the single source of that payload shape.
+/// block closes with a pointer to it, framed as a fallback for when the
+/// `session-message` skill is unavailable (matching the sender block's wording, so
+/// a recipient that already has the skill does not run a needless capabilities
+/// round trip). It carries no `send-message` payload command template — the skill
+/// body stays the single source of that payload shape.
 ///
 /// The trailing `session capabilities` line has no `from:`/`workspace:`/`reply_to:`
 /// prefix, so the frontend's `parseSessionMessageBlock` (`sessionMarkers.ts`)
@@ -58,7 +59,7 @@ pub fn build_session_message_block(from_name: &str, from_id: &str, workspace_fie
          from: {from_name}\t{from_id}\n\
          workspace: {workspace_field}\n\
          reply_to: {reply_to}\t(reply: session send-message, to=reply_to)\n\
-         For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`.\n\
+         If the session-message skill is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the full delivery contract.\n\
          {AIONUI_SESSION_MESSAGE_END_MARKER}"
     )
 }

--- a/crates/aionui-session-message/src/service_test.rs
+++ b/crates/aionui-session-message/src/service_test.rs
@@ -9,7 +9,7 @@ fn same_workspace_block_matches_the_spec_shape_exactly() {
          from: 重构-鉴权模块\tconv_1\n\
          workspace: same\n\
          reply_to: conv_1\t(reply: session send-message, to=reply_to)\n\
-         For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`.\n\
+         If the session-message skill is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the full delivery contract.\n\
          [[/AION_SESSION_MESSAGE]]"
     );
 }
@@ -42,12 +42,15 @@ fn the_block_always_states_how_to_reply() {
 
 #[test]
 fn the_block_carries_an_unconditional_capabilities_fallback_without_breaking_reply_to() {
-    // Even when the `session-message` skill is unchecked, the recipient can fetch
-    // the whole contract. The pointer sits on its OWN line, so it neither matches
-    // the `reply_to:` prefix nor the `\t` the frontend splits the address on.
+    // The pointer is always emitted (no skill-toggle branch), framed as a fallback
+    // for when the skill is unavailable so the recipient can still fetch the whole
+    // contract. It sits on its OWN line, so it neither matches the `reply_to:`
+    // prefix nor the `\t` the frontend splits the address on.
     let block = build_session_message_block("A", "conv_1", "same", "conv_1");
     assert!(
-        block.contains("For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`."),
+        block.contains(
+            "If the session-message skill is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the full delivery contract."
+        ),
         "{block}"
     );
     let reply_line = block

--- a/crates/aionui-session-message/tests/delivery_semantics.rs
+++ b/crates/aionui-session-message/tests/delivery_semantics.rs
@@ -230,10 +230,12 @@ async fn an_idle_target_is_delivered_and_actually_starts_a_turn() {
     assert!(content.starts_with("[[AION_SESSION_MESSAGE]]"), "{content}");
     assert!(content.contains(&format!("reply_to: {}", from.id)), "{content}");
     assert!(content.contains("workspace: same"), "{content}");
-    // The delivered block carries the unconditional capabilities fallback, so a
-    // recipient with the skill unchecked can still fetch the full contract.
+    // The delivered block carries the capabilities fallback, so a recipient with
+    // the skill unavailable can still fetch the full contract.
     assert!(
-        content.contains("For the full delivery contract, run `\"$AIONUI_HELPER_BIN\" session capabilities`."),
+        content.contains(
+            "If the session-message skill is unavailable, run `\"$AIONUI_HELPER_BIN\" session capabilities` for the full delivery contract."
+        ),
         "{content}"
     );
     assert!(content.trim_end().ends_with("接口定完了吗？"), "{content}");


### PR DESCRIPTION
## Summary

Wording-alignment follow-up to #952 (merged).

The recipient block (`[[AION_SESSION_MESSAGE]]`) pointed at `session capabilities` unconditionally — *"For the full delivery contract, run ..."* — which reads as always-required. That could nudge a recipient that already has the `session-message` skill into a needless `session capabilities` round trip, and it clashed in tone with the sender block and with the `the_skill_points_at_capabilities_only_as_a_fallback` content guard, both of which frame capabilities strictly as a fallback.

This rewords the recipient line to match the sender block's conditional framing:

> If the session-message skill is unavailable, run `"$AIONUI_HELPER_BIN" session capabilities` for the full delivery contract.

The pointer is still **emitted unconditionally** (no skill-toggle branch); only the phrasing changes. It stays on its own line with no `from:`/`workspace:`/`reply_to:` prefix and no tab, so the frontend parser still ignores it and `reply_to` address extraction is unchanged.

## What changed

- **`aionui-session-message/src/service.rs`**: recipient block line reworded to the conditional/fallback framing; doc comment updated (still notes the line is always emitted, UI-safe, and carries no `send-message` payload template).
- **`service_test.rs`**: the exact-shape assertion and the reply-to-safety assertion updated to the new text (the "line is always present" semantics are unchanged).
- **`tests/delivery_semantics.rs`**: happy-path assertion updated to the new text.
- **`SKILL.md`** (builtin auto-inject skill): recipient example block synced.

Sender block, `team` messaging, and the `session_skill.rs` anchor guard are untouched (the guard anchors on start-of-line runnable commands; this inline mention doesn't affect it — verified by the full suite).

## Runtime Verification

Verified by the automated suite and confirmed in a dev environment.

**Automated:** full pre-push gate green — migration-immutability check, workspace lint, format check, and the complete `cargo nextest` workspace suite (9325 tests passed).

**Dev environment (latest build):** ran real `@@` sends/replies and inspected the stored messages and structured logs (local paths, conversation ids/names, and model names omitted here).

- The recipient block now emits the reworded conditional-fallback line, and `reply_to` address parsing is unaffected.
- Real cross-session sends/replies across all four agent backends (codex, claude, opencode, aionrs) were all accepted (`delivered`), with no failures (no unreachable-target / reject / rate-limit).
- The skill-off fallback path remains functional: a recipient without the `session-message` skill fetched the contract via `session capabilities` and completed delivery end-to-end.
