### PR TITLE
Windows JSON-hook command line is not cmd.exe-safe

### DIFF
--- a/crates/aionui-ai-agent/src/antigravity_hook.rs
+++ b/crates/aionui-ai-agent/src/antigravity_hook.rs
@@ -81,15 +81,43 @@ pub fn remove_hooks_json(workspace: &Path) {
 /// The `matcher: "*"` is deliberate — AionUi decides per call, so agy must ask
 /// about all of them.
 ///
-/// `command` is a COMMAND LINE, not a bare path: agy word-splits it and honours
-/// double quotes (verified against agy 1.1.8, including a path containing
-/// spaces). Both details are load-bearing — without the subcommand agy would
-/// launch the whole backend instead of the hook, and without the quotes any
-/// install path containing a space would break word splitting.
+/// `command` is a COMMAND LINE, not a bare path. Unix/agy word-splits it and
+/// honours double quotes (verified against agy 1.1.8, including a path
+/// containing spaces). On Windows the same quoted-exe form is executed through
+/// `cmd.exe` by the JSON-hook runner (`jsonhook__aionui-permission-bridge_*`),
+/// which treats a command that *starts* with `"` as the program name *including
+/// the quote characters* — `'\"C:\\...\\aioncore.exe\"' is not recognized as
+/// an internal or external command` (AionUi#4095 follow-up; Program Files
+/// install: `"C:/Program Files/.../aioncore.exe"` with forward slashes).
+///
+/// Both the subcommand and platform-correct quoting are load-bearing — without
+/// the subcommand the agent would launch the whole backend instead of the hook.
 pub fn write_hooks_json(workspace: &Path, hook_binary: &Path) -> std::io::Result<()> {
     let dir = workspace.join(AGENTS_DIR);
     std::fs::create_dir_all(&dir)?;
     std::fs::write(dir.join("hooks.json"), hooks_json_body(hook_binary).as_bytes())
+}
+
+/// Build the `hooks.json` `command` value for `hook_binary`.
+///
+/// `windows` is injected so tests can lock both encodings without being compiled
+/// on that OS. Production always passes `cfg!(windows)`.
+pub(crate) fn hook_command_line_for(hook_binary: &Path, windows: bool) -> String {
+    let mut path = hook_binary.to_string_lossy().into_owned();
+    if windows {
+        // current_exe() / Electron can yield forward slashes; cmd.exe then
+        // treats `/win32-x64` as a switch. Always use backslashes on Windows.
+        path = path.replace('/', "\\");
+        if path.len() >= 2 && path.starts_with('"') && path.ends_with('"') {
+            path = path[1..path.len() - 1].to_string();
+        }
+        // `call` is a cmd builtin, so the subsequent quoted path is an argument
+        // to `call`, not argv[0]. A line that starts with `"` is the #4095
+        // follow-up failure mode.
+        format!("call \"{path}\" {HOOK_SUBCOMMAND}")
+    } else {
+        format!("\"{path}\" {HOOK_SUBCOMMAND}")
+    }
 }
 
 /// The `hooks.json` contents, without writing them.
@@ -99,11 +127,7 @@ pub fn write_hooks_json(workspace: &Path, hook_binary: &Path) -> std::io::Result
 /// (it knows the workspace, not where AionUi's binary lives). Handing it the
 /// prepared body lets it restore the gate when the user asks for it back.
 pub fn hooks_json_body(hook_binary: &Path) -> String {
-    // A COMMAND LINE, not a bare path: agy word-splits it and honours double
-    // quotes (verified against 1.1.8, including a path containing spaces).
-    // Without the subcommand agy would launch the whole backend; without the
-    // quotes any install path with a space would break word splitting.
-    let command = format!("\"{}\" {HOOK_SUBCOMMAND}", hook_binary.to_string_lossy());
+    let command = hook_command_line_for(hook_binary, cfg!(windows));
     let body = serde_json::json!({
         AntigravityHookConfig::HOOK_NAME: {
             "enabled": true,
@@ -175,7 +199,7 @@ mod tests {
         // launch the whole backend instead of the hook.
         assert_eq!(
             entry["PreToolUse"][0]["hooks"][0]["command"],
-            "\"/opt/aionui/backend\" antigravity-hook"
+            hook_command_line_for(Path::new("/opt/aionui/backend"), cfg!(windows))
         );
 
         // The decision must never be baked into the file: AionUi owns it at
@@ -195,7 +219,69 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(
             v[AntigravityHookConfig::HOOK_NAME]["PreToolUse"][0]["hooks"][0]["command"],
+            hook_command_line_for(Path::new("/Apps/Aion UI/backend"), cfg!(windows))
+        );
+    }
+
+    #[test]
+    fn unix_command_line_quotes_the_path_and_keeps_the_subcommand() {
+        assert_eq!(
+            hook_command_line_for(Path::new("/opt/aionui/backend"), false),
+            "\"/opt/aionui/backend\" antigravity-hook"
+        );
+        assert_eq!(
+            hook_command_line_for(Path::new("/Apps/Aion UI/backend"), false),
             "\"/Apps/Aion UI/backend\" antigravity-hook"
+        );
+    }
+
+    #[test]
+    fn windows_command_line_does_not_start_with_a_quote() {
+        // cmd.exe / jsonhook: a command that starts with `"` is looked up as a
+        // file whose name includes the quote characters.
+        let command = hook_command_line_for(
+            Path::new(r"C:\Program Files\AionUi\resources\bundled-aioncore\win32-x64\aioncore.exe"),
+            true,
+        );
+        assert!(
+            !command.starts_with('"'),
+            "Windows hook command must not start with a quote, got {command}"
+        );
+        assert_eq!(
+            command,
+            r#"call "C:\Program Files\AionUi\resources\bundled-aioncore\win32-x64\aioncore.exe" antigravity-hook"#
+        );
+        assert!(command.contains("antigravity-hook"));
+        assert!(
+            !command.contains(r#"\\?\"#),
+            "verbatim prefix must not leak into the hook command"
+        );
+    }
+
+    #[test]
+    fn windows_command_line_normalizes_forward_slashes() {
+        // Electron / current_exe() can yield C:/Program Files/...; cmd.exe then
+        // treats /win32-x64 as a switch. Reproduce the reported stderr path.
+        let command = hook_command_line_for(
+            Path::new("C:/Program Files/AionUi/resources/bundled-aioncore/win32-x64/aioncore.exe"),
+            true,
+        );
+        assert_eq!(
+            command,
+            r#"call "C:\Program Files\AionUi\resources\bundled-aioncore\win32-x64\aioncore.exe" antigravity-hook"#
+        );
+        assert!(!command.contains('/'), "Windows hook command must not keep forward slashes: {command}");
+    }
+
+    #[test]
+    fn windows_command_line_strips_already_quoted_paths() {
+        let command = hook_command_line_for(
+            Path::new(r#""C:\Program Files\AionUi\aioncore.exe""#),
+            true,
+        );
+        assert_eq!(
+            command,
+            r#"call "C:\Program Files\AionUi\aioncore.exe" antigravity-hook"#
         );
     }
 


### PR DESCRIPTION
## Windows JSON-hook command line is not cmd.exe-safe

### Summary

The PreToolUse permission bridge (`aionui-permission-bridge`) writes a **command line** (not a bare path) into `<workspace>/.agents/hooks.json`. Unix/agy word-splits that string and honours double quotes. On Windows the same string is executed through `cmd.exe` by the JSON-hook runner (`jsonhook__aionui-permission-bridge_PreToolUse_0_0`).

A command that **starts with a quote** is treated as the program name *including the quote characters*:

```
JSON hook "jsonhook__aionui-permission-bridge_PreToolUse_0_0" failed: command failed: exit status 1, stderr: "C:/Program Files/AionUi/resources/bundled-aioncore/win32-x64/aioncore.exe" is not recognized as an internal or external command
```

(Quote characters included in the reported program name; path uses forward slashes.)

This is the leftover of iOfficeAI/AionUi#4095 after iOfficeAI/AionCore#887 stripped the `\\?\` verbatim prefix with `dunce::canonicalize`. The reporter’s follow-up on #4095 is the same class of failure without `\\?\`:

```
'"C:\Users\<user>\AppData\Local\Programs\AionUi\resources\bundled-aioncore\win32-x64\aioncore.exe"' is not recognized as an internal or external command
```

### Root cause

**File:** `crates/aionui-ai-agent/src/antigravity_hook.rs`  
**Function:** `hooks_json_body` / former one-liner

```rust
format!("\"{}\" {HOOK_SUBCOMMAND}", hook_binary.to_string_lossy())
```

Always produced `"<path>" antigravity-hook`. Combined with:

1. `cmd.exe` quote-eating when the JSON-hook runner does `cmd /c <command>`
2. Electron/`current_exe()` sometimes yielding **forward slashes** (`C:/Program Files/...`), which cmd then treats as switches

…the quoted path is looked up as a literal filename.

Hook command strings are generated at session start (`factory/antigravity.rs` → `permission_hook_body`) and persisted on the session. After an AionCore/AionUi **server restart**, live sessions restore that body via `sync_permission_hook` (`crates/aionui-session/src/backend/antigravity/conn.rs`) without rebuilding argv. New sessions generate the command and spawn in one flow. **This PR does not invent a second generator** — if the stored string is cmd-hostile, restore-after-restart is the path that re-applies it to an already-running agent whose JSON-hook runner uses cmd.exe. New sessions after restart working is consistent with backends that do **not** install this hook (`factory/acp.rs` sets `permission_hook_body: None`) or with a freshly spawned process that word-splits the command itself. If a new Windows Claude/agy session still hits jsonhook+cmd, it would fail the same way until this command-line encoding is fixed.

### Fix

Build the command with an explicit Windows encoding:

- normalize `/` → `\`
- strip a wrapping quote pair if the path already came quoted
- prefix with the `call` builtin so quotes wrap an **argument**, not argv[0]
- keep the `antigravity-hook` subcommand (bare exe would start the resident backend)

Unix encoding is unchanged.

### Tests

Assertions on the generated command string (no Electron build):

- Unix: `"/opt/..." antigravity-hook` (quoted path, subcommand present)
- Windows Program Files + forward slashes → `call "C:\Program Files\...\aioncore.exe" antigravity-hook`
- Windows command must not start with `"`
- Windows command must not contain `/` or `\\?\`

### Reproduce (pre-fix)

1. Windows install under `C:\Program Files\AionUi\` (space in path).
2. Start a session that installs the permission-bridge PreToolUse hook.
3. Restart the AionUi/AionCore **server** while that session is still running.
4. Invoke any tool. JSON hook fails with the quoted `aioncore.exe` path as an unknown command.
5. Open a **new** session after the restart: hook injection / tool permission may succeed (ACP path, or a fresh spawn).
