### PR TITLE
chore(acp): bump codebuddy, dimcode, dirac, glm, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.141.0"
+      "version": "2.142.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,27 +19,27 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.22"
+      "version": "0.3.25"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.6.1"
+      "version": "1.7.0"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.12"
+      "version": "1.0.13"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.5.5"
+      "version": "7.5.6"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.141.0",
+                "@tencent-ai/codebuddy-code@2.142.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync, covering three days of drift (the 2026-08-30 and 08-31 runs did not execute; the state file's last checked tag was `v2026.08.28-e9b1b2d`). Six npx pins drifted since #943, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.141.0 → **2.142.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.22 → **0.3.25** | ok (agentInfo version 0.3.25) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.5.1 → **0.5.2** | ok (agentInfo dirac 0.5.2) | **succeeded** unauthenticated |
| glm-acp-agent | `glm-acp-agent` | 1.6.1 → **1.7.0** | ok (protocolVersion 1) | **succeeded** unauthenticated |
| grok | `@xai-official/grok` | 1.0.12 → **1.0.13** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.5.5 → **7.5.6** | ok (agentInfo Kilo 7.5.6) | **succeeded** unauthenticated |

All six meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials, and every entrypoint is unchanged from the previous snapshot.

glm-acp-agent is the one bump crossing a minor version (1.6.x → 1.7.0), so its entrypoint was exercised rather than assumed: the Registry distribution still declares a bare `glm-acp-agent` invocation with no arguments, and that exact call completed `initialize` and opened a session advertising thought_level, mode, and model options. It also continues to self-report `agentInfo.version` as `1.0.0` while the package is 1.7.0 — a standing vendor quirk, not an AionCore defect. dimcode likewise still reports `agentInfo.title` "DimAgent" against a public listing that says "DimCode". No session catalog is persisted (skill step 11 leaves those columns to the runtime), and no metadata changes ride along.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.141.0` → `2.142.0`. All six outgoing versions were grepped across `crates/**/*.rs` before staging; codebuddy's was the only real assertion. The other hits were verified false positives from substring and wildcard matching: `0.3.22` inside a `@anthropic-ai/claude-agent-sdk 0.3.220` comment, `0.5.1` inside `"block005-1111"` and a Discord snowflake timestamp, `1.6.1` inside npm `11.6.1` version-parser fixtures. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions, and changing them would break their hash expectations.

The other 5 Registry-pinned packages (autohand, deepagents, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.31-f6fdb56`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.31-f6fdb56/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
