### PR TITLE
chore(cli-version): verify codex against 0.151.0

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -37,7 +37,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// on does complete turns and passes the suite, so the gate walks forward over
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
-pub const VERIFIED_CODEX_VERSION: &str = "0.150.1";
+pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.22";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
@@ -456,10 +456,10 @@ mod tests {
 
     #[test]
     fn components_compare_numerically_not_lexically() {
-        // The bug a string compare would introduce: "0.150.1" < "0.99.0"
-        // lexically, but 150 > 99.
+        // The bug a string compare would introduce: "0.151.0" < "0.99.0"
+        // lexically, but 151 > 99.
         assert_eq!(classify("0.99.0", VERIFIED_CODEX_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("0.150.2", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("0.151.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
     }
 
     #[test]
@@ -568,9 +568,9 @@ mod tests {
     fn local_codex_output_is_classified_as_newer() {
         // Real `codex --version` output shape, one release above the verified
         // one so the newer path is what gets exercised.
-        assert_eq!(parse_version("codex-cli 0.151.0"), Some(vec![0, 151, 0]));
-        let (level, _, localized) = drift_notice("codex", "codex-cli 0.151.0", VERIFIED_CODEX_VERSION)
-            .expect("0.151.0 drifts from the verified release");
+        assert_eq!(parse_version("codex-cli 0.152.0"), Some(vec![0, 152, 0]));
+        let (level, _, localized) = drift_notice("codex", "codex-cli 0.152.0", VERIFIED_CODEX_VERSION)
+            .expect("0.152.0 drifts from the verified release");
         assert_eq!(level, NoticeLevel::Info);
         assert_eq!(localized.code, CODE_CLI_VERSION_NEWER);
 
@@ -578,10 +578,10 @@ mod tests {
         // verified release is told nothing, and this breaks if a bump lands
         // without re-verifying against that exact binary.
         assert_eq!(
-            classify("codex-cli 0.150.1", VERIFIED_CODEX_VERSION),
+            classify("codex-cli 0.151.0", VERIFIED_CODEX_VERSION),
             VersionVerdict::Verified
         );
-        assert!(drift_notice("codex", "codex-cli 0.150.1", VERIFIED_CODEX_VERSION).is_none());
+        assert!(drift_notice("codex", "codex-cli 0.151.0", VERIFIED_CODEX_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Moves `VERIFIED_CODEX_VERSION` from 0.150.1 to 0.151.0.

| Gate | Result |
| --- | --- |
| A — contract | **PASS** — 411 → 413 schema files, `ServerNotification` 79 → 79, `ClientRequest` 153 → 154, nothing removed, no enum value dropped |
| B — live e2e | **PASS 11/11**, 427.58s |
| C — release notes | **CLEAR** — 27 notes, 0 REVIEW |

## Gate C: two notes land on app-server, and both are exercised

Most of the range is TUI, but two items touch the surface this repo actually drives:

- *"Preserved structured MCP tool and resource errors in app-server responses."* (#41196)
- *"Improve sandboxing, MCP errors, and cached approvals."* (#41196)

Both sound additive, and neither is left resting on that. The gate B run includes `live_codex_team_mcp_tools_call_and_runtime_env` (drives a real MCP tool call) and `live_codex_survives_a_broken_mcp_server` (drives an MCP server that fails) — both passed. Approval policy is covered by gate A on the enum side: no value was removed from either of the two enums the manifest depends on.

## The candidate is proven from the suite log

```
direct CLI version detected  cli=codex version=codex-cli 0.151.0
direct CLI version drift     cli=codex version=codex-cli 0.151.0
```

All 11 sessions, each with the drift line that only appears because the binary disagrees with the not-yet-bumped constant. Installed codex on this machine is 0.148.0, so a shim failure would have been visible immediately. `latest` on npm is `0.151.0`; `alpha` is separately at `0.152.0-alpha.7` and was not touched.

## Tests

Three pinned fixtures re-pointed above the new constant rather than loosened, and the literal verified-release assertion now names `codex-cli 0.151.0`. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

0.147.0 remains deliberately unverified — the gate walks over it rather than through it, so it never becomes an accepted floor.

Record: `~/aion/protocols/samples/codex-cli/0.151.0/`

Constants and record only — no source change.