### PR TITLE
feat(scm): enumerate a repository's linked worktrees during discovery

### DIFF
--- a/crates/aionui-project/src/scm/git_provider.rs
+++ b/crates/aionui-project/src/scm/git_provider.rs
@@ -313,6 +313,111 @@ fn canonical_key(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
+/// The path of `target` relative to `root_key`, as a normalized forward-slash
+/// string, or `None` when `target` is not strictly inside `root_key`. Both sides
+/// are canonicalized before comparison (macOS realpath/case tolerance, matching
+/// `canonical_key`). Returns `None` for the root itself (empty relative) and for
+/// any path that would need `..` or a root/prefix component to reach: a surfaced
+/// repository must be a clean descendant, expressible as a pe-relative `FileRef`
+/// (`FileRef.relative_path` is pe-anchored — no `..`, no absolute — by contract).
+fn pe_relative_path(root_key: &Path, target: &Path) -> Option<String> {
+    let target_key = canonical_key(target);
+    let rel = target_key.strip_prefix(root_key).ok()?;
+    let mut parts = vec![];
+    for comp in rel.components() {
+        match comp {
+            std::path::Component::Normal(segment) => parts.push(segment.to_str()?.to_owned()),
+            // `..`, a root, or a Windows prefix cannot occur inside a strict
+            // descendant; treat any of them as "not representable" rather than
+            // fabricating a path that violates the FileRef contract.
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+/// Enumerate the linked worktrees of the repository at `repo_path`, surfacing each
+/// whose work tree lives inside `pe_root_key` (a canonicalized pe root).
+///
+/// A worktree outside the pe root is skipped with a log: it has no pe-relative
+/// path, and every SCM identity (a repo root, a resource file) is pe-anchored by
+/// contract, so it cannot be represented. This is why the enumeration is bounded
+/// to the pe subtree rather than surfacing every worktree git knows.
+///
+/// The worktree set is asked from git (`Repository::worktrees`), never scanned
+/// from the filesystem, so a submodule or nested repository is never mistaken for
+/// a worktree — and worktrees the one-level child walk cannot reach (deeper than
+/// one level, or behind a dot-directory such as `.worktrees/`) are still found.
+///
+/// Any failure — an unreadable set, a pruned/locked entry, a path that no longer
+/// opens, a transient race — drops that entry and keeps discovery going: a
+/// worktree is an enrichment, never a reason to fail the primary's discovery.
+fn enumerate_linked_worktrees(repo_path: &Path, pe_root_key: &Path) -> Vec<OpenedRepo> {
+    let repo = match Repository::open(repo_path) {
+        Ok(repo) => repo,
+        Err(err) => {
+            tracing::debug!(?repo_path, error = %err, "scm discover: reopen for worktree enumeration failed, skipping");
+            return vec![];
+        }
+    };
+    let names = match repo.worktrees() {
+        Ok(names) => names,
+        Err(err) => {
+            tracing::debug!(?repo_path, error = %err, "scm discover: worktree list failed, skipping");
+            return vec![];
+        }
+    };
+
+    let mut out = vec![];
+    for entry in names.iter() {
+        // `StringArray::iter` yields `Result<Option<&str>, _>`: an iteration error
+        // or a non-UTF-8 name is skipped (neither can address a pe-relative path).
+        let Ok(Some(name)) = entry else {
+            continue;
+        };
+        let worktree = match repo.find_worktree(name) {
+            Ok(worktree) => worktree,
+            Err(err) => {
+                tracing::debug!(name, error = %err, "scm discover: find_worktree failed, skipping");
+                continue;
+            }
+        };
+        let wt_path = worktree.path();
+        let Some(relative_path) = pe_relative_path(pe_root_key, wt_path) else {
+            tracing::debug!(
+                name,
+                ?wt_path,
+                "scm discover: linked worktree lives outside the pe root, not surfaced"
+            );
+            continue;
+        };
+        match open_repo(wt_path, relative_path) {
+            Ok(Some(opened)) => out.push(opened),
+            // A pruned, bare, or already-gone worktree opens to nothing.
+            Ok(None) => {}
+            Err(err) => {
+                tracing::debug!(name, error = %err, "scm discover: worktree open failed, skipping");
+            }
+        }
+    }
+    out
+}
+
+/// Drop repeated repositories by canonicalized work-tree path, keeping the first.
+///
+/// A linked worktree can be reached two ways in one discovery — enumerated from
+/// its primary, and (in the workspace-container case) also walked as an immediate
+/// child directory — and both carry the same work tree. Keeping the first
+/// preserves the child walk's `relative_path`, which for an immediate-child
+/// worktree equals the enumerated one anyway.
+fn dedup_by_workdir(opened: &mut Vec<OpenedRepo>) {
+    let mut seen = std::collections::HashSet::new();
+    opened.retain(|o| seen.insert(canonical_key(&o.workdir)));
+}
+
 /// Run one `statuses()` pass, with the stale-index fallback.
 ///
 /// Index writeback is on by default because without it a single external
@@ -839,18 +944,41 @@ impl IScmProvider for GitScmProvider {
         // returns just the plain data each surfaced repository needs; identity
         // and registry insertion stay on the async side.
         let opened = tokio::task::spawn_blocking(move || -> Result<Vec<OpenedRepo>, git2::Error> {
-            // `open` (not `discover`): a root is at most one repo — never walk up
-            // to a parent repository, never enumerate nested ones. A submodule is
-            // therefore never mis-captured, since we never descend into a repo.
-            if let Some(opened) = open_repo(&root_path, String::new())? {
-                return Ok(vec![opened]);
+            let pe_root_key = canonical_key(&root_path);
+
+            // Base set. `open` (not `discover`): a root is at most one repo — never
+            // walk up to a parent repository, never enumerate nested ones. A
+            // submodule is therefore never mis-captured, since we never descend
+            // into a repo.
+            let mut opened = if let Some(root_repo) = open_repo(&root_path, String::new())? {
+                vec![root_repo]
+            } else if discover_children {
+                // The root itself is not a repository: relax by exactly one level
+                // and surface each immediate child directory that is a repository.
+                discover_child_repos(&root_path)
+            } else {
+                vec![]
+            };
+
+            // Enrich: also surface each surfaced repo's linked worktrees that live
+            // inside the pe root tree. The worktree set comes from git, not a
+            // filesystem scan, so this reaches worktrees the child walk never would
+            // (deeper than one level, or behind a dot-directory like `.worktrees/`)
+            // while still never mis-capturing a submodule or nested repo. Bounded
+            // to the pe subtree because a worktree outside it has no pe-relative
+            // `FileRef` (see `enumerate_linked_worktrees`).
+            let mut worktrees = vec![];
+            for repo in &opened {
+                if repo.is_worktree {
+                    continue;
+                }
+                worktrees.extend(enumerate_linked_worktrees(&repo.workdir, &pe_root_key));
             }
-            if !discover_children {
-                return Ok(vec![]);
-            }
-            // The root itself is not a repository: relax by exactly one level and
-            // surface each immediate child directory that is a repository.
-            Ok(discover_child_repos(&root_path))
+            opened.extend(worktrees);
+            // A worktree can be both enumerated and (in the container case) walked
+            // as a child; surface it once.
+            dedup_by_workdir(&mut opened);
+            Ok(opened)
         })
         .await
         .map_err(|err| ScmError::OperationFailed {

--- a/crates/aionui-project/src/scm/git_provider_test.rs
+++ b/crates/aionui-project/src/scm/git_provider_test.rs
@@ -293,6 +293,63 @@ async fn workspace_worktree_without_primary_has_none_owner() {
 }
 
 #[tokio::test]
+async fn root_repo_surfaces_its_internal_linked_worktree() {
+    // The pe root is itself a repository (the common "open the repo directly"
+    // case, discover_children = false). A linked worktree living inside the repo
+    // tree (e.g. `.worktrees/<name>`) is enumerated from git — never by scanning
+    // the filesystem — and surfaced as a child nested under the primary.
+    let tmp = TempDir::new().expect("tempdir");
+    let primary = init_committed_repo(tmp.path());
+    std::fs::create_dir_all(tmp.path().join(".worktrees")).expect("mkdir .worktrees");
+    let wt_path = tmp.path().join(".worktrees").join("feature");
+    primary.worktree("feature", &wt_path, None).expect("add worktree");
+
+    let provider = GitScmProvider::new();
+    // Attached-style root: discovery never scans children, yet the worktree must
+    // still surface — it comes from git enumeration, not the child-directory walk.
+    let root = root_at("pe1", tmp.path(), "zumi");
+    let repos = provider.discover(&root).await.expect("discover ok");
+
+    let primary_repo = by_child(&repos, ""); // relative_path == "" is the pe root itself
+    let worktree = by_child(&repos, ".worktrees/feature");
+
+    assert!(!primary_repo.is_worktree, "the pe root repo is the primary");
+    assert!(worktree.is_worktree, "the linked worktree is flagged");
+    assert_eq!(
+        worktree.worktree_of.as_deref(),
+        Some(primary_repo.repo_id.as_str()),
+        "the internal worktree points at its primary's repo_id"
+    );
+}
+
+#[tokio::test]
+async fn root_repo_skips_linked_worktree_outside_its_tree() {
+    // A linked worktree living OUTSIDE the pe root tree has no pe-relative path,
+    // so it cannot be represented as a FileRef and is not surfaced. Only the
+    // primary shows — the same one-repo result as a repo with no worktrees.
+    let tmp = TempDir::new().expect("tempdir repo");
+    let primary = init_committed_repo(tmp.path());
+    let outside = TempDir::new().expect("tempdir outside");
+    let wt_path = outside.path().join("feature");
+    primary.worktree("feature", &wt_path, None).expect("add worktree");
+
+    let provider = GitScmProvider::new();
+    let root = root_at("pe1", tmp.path(), "zumi");
+    let repos = provider.discover(&root).await.expect("discover ok");
+
+    assert_eq!(
+        repos.len(),
+        1,
+        "only the primary surfaces; the outside worktree is skipped"
+    );
+    assert!(!repos[0].is_worktree);
+    assert!(
+        repos[0].root.relative_path.is_empty(),
+        "the sole surfaced repo is the pe root itself"
+    );
+}
+
+#[tokio::test]
 async fn status_reports_untracked_as_created_unstaged() {
     let tmp = TempDir::new().expect("tempdir");
     let repo = init_repo(tmp.path());


### PR DESCRIPTION
## Summary

When a project root is itself a git repository, its linked worktrees were never surfaced in the Source Control panel. Discovery opens the root as at most one repository, and (only for a workspace root that is not itself a repo) scans one level of immediate child directories while skipping dot-directories. A repository's own linked worktrees — typically under `.worktrees/<name>` — are therefore invisible.

This change enumerates a repository's linked worktrees from git itself (`Repository::worktrees` / `find_worktree`) during discovery and surfaces those living inside the project-root tree, so each nests under its primary in the panel via the existing `worktree_of` correlation — with no frontend, wire, or DB change.

## What changed

`crates/aionui-project/src/scm/git_provider.rs`:

- **`enumerate_linked_worktrees`** — asks git for the worktree set (never scans the filesystem, so a submodule or nested repo is never mis-captured) and opens each worktree that resolves inside the project root.
- **`pe_relative_path`** — computes a worktree's path relative to the project root; rejects anything needing `..` or an absolute/root component (not representable as a pe-relative `FileRef`).
- **`dedup_by_workdir`** — a worktree can be both enumerated and walked as a child (workspace-container case); surface it once.
- **`discover`** — now appends each surfaced non-worktree repo's in-tree linked worktrees, reusing the existing `worktree_of` correlation and repository-building code.

## Scope / boundary

- Enumeration applies to every surfaced non-worktree repository (a root that is itself a repo, and each child repo under a workspace container).
- Only worktrees **inside** the project-root tree are surfaced. A worktree outside the tree has no pe-relative `FileRef` and is skipped with a debug log; supporting it would require an absolute-root escape hatch threaded through identity/diff/containment, intentionally out of scope.
- The worktree set comes from git, not a filesystem scan, so worktrees behind dot-directories or deeper than one level are reachable while submodules/nested repos are never mis-captured.

## Runtime verification

Built this branch and exercised the Source Control panel against a repository opened directly as the project root, with several linked worktrees created at different locations:

- Worktree at the conventional `.worktrees/<name>` → surfaced, nested under its primary.
- Worktree at a hidden, multi-level path (a dot-directory several levels deep) → surfaced, confirming enumeration reaches where the one-level, dot-skipping child walk cannot.
- Worktree at a non-conventional in-tree path → surfaced, confirming location independence.
- Worktree living outside the project-root tree → correctly not surfaced; the skip is recorded in a debug log.
- Selecting a worktree carrying staged + unstaged + untracked changes → change list shows the correct staged/unstaged groups and states.
- Clean worktrees → "no changes".

No screenshots attached (the states are text-only lists whose content is covered by the scenarios above).

## Test plan

- [x] `cargo test` for `aionui-project` — added `root_repo_surfaces_its_internal_linked_worktree` and `root_repo_skips_linked_worktree_outside_its_tree`.
- [x] Full workspace suite via `just push` (9327 passed).
- [x] `cargo fmt --check` and `clippy` clean.
