### PR TITLE
chore(acp): bump codebuddy, dimcode, glm and grok registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.142.0"
+      "version": "2.143.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.25"
+      "version": "0.3.26"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -29,12 +29,12 @@
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.7.0"
+      "version": "1.8.0"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.13"
+      "version": "1.0.16"
     },
     "kilo": {
       "registry_json_id": "kilo",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.142.0",
+                "@tencent-ai/codebuddy-code@2.143.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #957, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.142.0 → **2.143.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.25 → **0.3.26** | ok (agentInfo version 0.3.26) | auth required (`-32000`, "Provider credentials are required") |
| glm-acp-agent | `glm-acp-agent` | 1.7.0 → **1.8.0** | ok (protocolVersion 1) | **succeeded** unauthenticated |
| grok | `@xai-official/grok` | 1.0.13 → **1.0.16** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |

All four meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

glm-acp-agent crosses another minor (1.7.0 → 1.8.0), so its entrypoint was exercised rather than assumed: the Registry distribution still declares a bare `glm-acp-agent` call with no arguments, and that exact invocation completed `initialize` and opened a session advertising thought_level, mode, and model options. It still self-reports `agentInfo.version` as `1.0.0`, and dimcode still reports `agentInfo.title` "DimAgent" against a public listing of "DimCode" — both standing vendor quirks, not AionCore defects. No session catalog is persisted (skill step 11 leaves those columns to the runtime).

**Snapshot diff beyond the lock:** comparing the raw CDN JSON against the previous snapshot, every change is version churn with no structural movement — no distribution type was added or removed, and no entrypoint args or env changed for any of the 39 agents. Two binary distributions moved (`cursor` to lab build 2026.08.25-3e8eec8, `harn` to v0.10.125 with a new sha256) and `factory-droid`'s npx package moved to 0.209.0; none of the three is in our release lock, so all are report-only here per the drift workflow's separate treatment of binary distributions.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.142.0` → `2.143.0`. All four outgoing versions were scanned across `crates/**/*.rs` before staging, using fixed-string matching; codebuddy's is the only real assertion and the other three have no hits at all. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions, and changing them would break their hash expectations.

The other 7 Registry-pinned packages (autohand, deepagents, dirac, kilo, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.01-fca7bdf`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.01-fca7bdf/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
