### PR TITLE
fix(codex): opt into update_plan so the plan card survives 0.152.0

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
@@ -178,6 +178,8 @@ mod tests {
                 "-c",
                 "shell_environment_policy.include_only=[]",
                 "-c",
+                "tools.update_plan.enabled=true",
+                "-c",
                 "sandbox_mode=\"danger-full-access\"",
                 "-c",
                 "windows.sandbox=\"unelevated\"",

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -45,17 +45,34 @@ use crate::event::{CancelReason, ProvisioningPhase, SessionEvent, StopReason, Su
 use futures_util::stream::{BoxStream, StreamExt};
 
 const CODEX_CONFIG_FLAG: &str = "-c";
+
+/// codex 0.152.0 made the `update_plan` tool opt-in: `UpdatePlanToolConfig`
+/// lost its `default = "default_true"` and now defaults to `false`
+/// (openai/codex a9519cbc, "Make the update_plan tool opt-in" #41744, verified:
+/// the same commit flips `default: true` to `default: false` under this key in
+/// `codex-rs/core/config.schema.json`).
+///
+/// Without this override the model is never offered the tool, so no plan
+/// notification is ever emitted and AionUi's plan card stays permanently empty
+/// on codex >= 0.152.0. Measured with the live suite: 0.151.0 passes
+/// `live_codex_produces_a_plan` 2/2, 0.152.0 fails it 2/2 with no `plan` frame
+/// in the stream at all.
+///
+/// Harmless on older releases, which already defaulted this to true.
+const CODEX_UPDATE_PLAN_ENABLED: &str = "tools.update_plan.enabled=true";
 const CODEX_ENV_POLICY_INHERIT_ALL: &str = "shell_environment_policy.inherit=all";
 const CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY: &str = "shell_environment_policy.include_only=[]";
 
 /// Config overrides that make Codex command-execution children inherit the
 /// runtime environment injected into the app-server process.
-pub fn codex_shell_environment_policy_args() -> [&'static str; 4] {
+pub fn codex_shell_environment_policy_args() -> [&'static str; 6] {
     [
         CODEX_CONFIG_FLAG,
         CODEX_ENV_POLICY_INHERIT_ALL,
         CODEX_CONFIG_FLAG,
         CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY,
+        CODEX_CONFIG_FLAG,
+        CODEX_UPDATE_PLAN_ENABLED,
     ]
 }
 
@@ -8215,6 +8232,8 @@ mod tests {
                 "shell_environment_policy.inherit=all",
                 "-c",
                 "shell_environment_policy.include_only=[]",
+                "-c",
+                "tools.update_plan.enabled=true",
             ],
             "every app-server spawn must explicitly propagate the parent environment to commandExecution shells"
         );
@@ -9428,6 +9447,8 @@ mod tests {
                 "shell_environment_policy.inherit=all",
                 "-c",
                 "shell_environment_policy.include_only=[]",
+                "-c",
+                "tools.update_plan.enabled=true",
             ],
             "wake must restore the same explicit commandExecution environment policy as the initial spawn"
         );


### PR DESCRIPTION
codex 0.152.0 made the `update_plan` tool **opt-in**, so AionUi's plan card goes permanently empty on that release. This opts back in.

## What changed upstream

`UpdatePlanToolConfig` lost its `default = "default_true"` and now defaults to `false` — openai/codex `a9519cbc`, *"Make the update_plan tool opt-in"* (#41744). The same commit flips the default under that key in the machine-generated `codex-rs/core/config.schema.json`:

```diff
         "enabled": {
-          "default": true,
+          "default": false,
```

The model is therefore never offered the tool, no plan notification is ever emitted, and the card stays empty with **no error anywhere**. Not theoretical: 0.152.0 is npm's current `latest`, and we do not pin the user's CLI, so anyone who updates codex loses plan rendering silently.

## Measured, not inferred

The single live test against each binary through its own PATH shim:

| codex | `live_codex_produces_a_plan` |
| --- | --- |
| 0.151.0 (currently verified) | **2/2 pass** |
| 0.152.0 | **2/2 fail** — no `plan` frame anywhere in the stream |

With the override, 0.152.0 passes and the frame is back.

**The shim was proven to take, and here that mattered more than usual.** The installed codex on this machine is 0.148.0, where `update_plan` is still default-on — so a shim that silently failed would have produced a *passing* test against the wrong binary. A wrapper shim recorded every invocation:

```
INVOKED ver=codex-cli 0.152.0 argv=app-server -c shell_environment_policy.inherit=all
  -c shell_environment_policy.include_only=[] -c tools.update_plan.enabled=true
```

Full codex live suite with the fix: **11/11 against 0.152.0**, 484s, 58 recorded invocations — all the candidate, all carrying the override.

## The change

The override rides in the existing compatibility block (`codex_shell_environment_policy_args`), so it applies to both initial open and idle wake, and it is harmless on older releases which already defaulted it to true.

The two argv assertions were **updated, not loosened** — they still assert the full expected argv, which is exactly what lets them catch a dropped override later. `cargo test -p aionui-session --lib codex_conn`: 145/145. Clippy clean, fmt clean.

## Blocks the codex bump

`VERIFIED_CODEX_VERSION` stays at 0.151.0 until this lands: gate B is red on 0.152.0 without it, and a constant may not claim a verification its own tree cannot reproduce. The bump will follow in a later nightly run once this is on `main`.

Source change — left for human review, no auto-merge.
