### PR TITLE
chore(cli-version): verify agy against 1.1.23

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.22";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.23";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.22", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.22", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.23", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.21", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.22", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.22 to 1.1.23.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 139.53s |
| C — release notes | **CLEAR** — one REVIEW item, resolved by probe |

Gate B ran against a manifest download whose sha512 was checked before it executed; the log reports only `version=1.1.23`. The machine's own agy stayed on 1.1.18.

## The two sources swapped again

| source | covers |
| --- | --- |
| `agy changelog` from the 1.1.23 binary | 1.1.21, 1.1.22, **1.1.23** ← used |
| the rendered web changelog | 1.1.20, 1.1.21, 1.1.22 — no 1.1.23 |

Six days ago it was the other way round (the web page had 1.1.21/1.1.22 while the 1.1.22 binary's bundled copy stopped at 1.1.20). Neither is authoritative, so both are checked every run and the record says which was used.

## The REVIEW item, resolved by probing rather than arguing

> "Reduced subagent streaming overhead by sending subagent trajectory metadata once per subtrajectory instead of with every step."

This lands on a frame we parse. `translate.rs:264` reads `subagent_info` **on the ACTIVE frame** to name the subagent tool card, and `unwrap_or_default()` means a regression would degrade to a generic card rather than fail loudly — quiet, which is the dangerous kind.

**Gate B cannot resolve it**: no agy test in the suite dispatches a subagent. So it was probed directly, and the dispatch step still carries the list on both frames:

```
idx=2 state=ACTIVE  subagent_info=YES agents=1
idx=2 state=DONE    subagent_info=YES agents=1
```

The change is to trajectory metadata inside the subagent's own stream, not to the field we consume. Capture kept as `probe-subagent-dispatch.ndjson`.

**Attribution checked** — the probe binary was byte-identical before and after (`mtime=07:55:50 size=180065392 ver=1.1.23`, matching the values recorded at download). That check exists because an earlier run's agy A/B had to be retracted when a copy self-updated mid-probe.

## Upstream fixed a hang we already work around

> "Fixed commands with subcommands (such as `models` or `agents`) hanging on an inherited, unclosed standard input pipe instead of executing immediately."

That is the exact defect `probe_models` was built around — `models.rs:88-92` drops the stdin handle, citing a measurement against 1.1.9 (*"stdin left open = still running after 40 minutes; stdin closed = exits in ~3s"*). Our workaround is now belt-and-braces. It is harmless and still correct on older installs, so **nothing is changed here**; recorded so it can be retired deliberately if the floor ever rises past 1.1.23.

## Not our surface

Permission-prompt titles (agy's own interactive UI — we pass `--dangerously-skip-permissions` and render from our hook bridge), subagent `enable_mcp_tools` definitions, Gemini history reconstruction, and Windows BOM parsing of the MCP config file we do not write.

## Tests

Pinned assertions moved with the constant, including the literal verified-release case. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.23/`

Constants and record only — no source change.
