### PR TITLE
chore(acp): bump dimcode, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.26"
+      "version": "0.3.27"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.16"
+      "version": "1.0.17"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.5.6"
+      "version": "7.5.9"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Three npx pins drifted since #960, each backed by a fresh serial ACP probe of the exact pinned version. This one is a single-file diff: no lock-derived test assertion embeds any of the three versions, and codebuddy — the only package whose version appears in a test — did not drift.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.26 → **0.3.27** | ok (agentInfo version 0.3.27) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 1.0.16 → **1.0.17** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.5.6 → **7.5.9** | ok (agentInfo Kilo 7.5.9) | **succeeded** unauthenticated |

All three meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials. kilo opened a session advertising model, thought_level, and mode options; that catalog is evidence only and is not persisted (skill step 11 leaves those columns to the runtime). dimcode still self-reports `agentInfo.title` as "DimAgent" against a public listing of "DimCode" — a standing vendor quirk, not an AionCore defect.

**Snapshot diff beyond the lock:** a per-agent comparison of the raw CDN JSON against the previous snapshot shows every change is version churn — no distribution type was added or removed, and no entrypoint args or env changed for any of the 39 agents. Twelve non-lock agents also moved (claude-acp 0.73.0, cline 3.0.61, codex-acp 1.8.0, gemini-cli 0.58.0, factory-droid, plus binary artifacts for cursor, devin, harn, junie, kimi, opencode, and kilo's own binary channel). None of them is in our release lock, so all are report-only here; binary distributions in particular stay out of scope per the drift workflow's separate treatment of platform artifacts.

**Derived-assertion scan:** all three outgoing versions (`0.3.26`, `1.0.16`, `7.5.6`) were scanned across `crates/**/*.rs` with fixed-string matching before staging, and none has a single hit. `registry_npx_lock.rs` still pins codebuddy at `2.143.0`, which is correct — codebuddy is unchanged in this snapshot. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 8 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.02-fa32608`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.02-fa32608/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: this is a lock version bump only; existing startup/session error paths already identify a failing agent by backend.
