### PR TITLE
chore(cli-version): verify agy against 1.1.24

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.23";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.24";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.23", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.24", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.22", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.25", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.23 to 1.1.24.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 148.71s |
| C — release notes | **CLEAR** — every entry is a fix, none changes a contract |

Gate B ran against a manifest download whose sha512 was checked before it executed. The log reports only `version=1.1.24`, and the binary was byte-identical before and after (`mtime=08:58:30 size=180362000`) — that check exists because an earlier agy A/B had to be retracted when a copy self-updated mid-probe. The machine's own agy stayed on 1.1.18.

## One entry lands on our run shape

> "Fixed headless CLI invocations with piped standard output or standard error hanging on exit by setting `FD_CLOEXEC` on the preserved streams so child processes do not keep the caller's pipes open."

That is exactly how we invoke agy: print mode, `--output-format stream-json`, stdout piped and read to EOF. A tool that spawned a child holding the inherited pipe could keep the stream from ever closing.

It is the **third fd-inheritance hang agy has fixed in two releases** — 1.1.23 fixed `agy models` hanging on an inherited unclosed *stdin*, which `models.rs:88-92` already works around by dropping the handle. The pattern is worth more than any single instance: agy has repeatedly shipped fd bugs around headless invocation, which is the only way we invoke it.

Nothing to opt into and no frame changes, so not a REVIEW item — it simply removes a class of stall we could not have told apart from a slow model.

## Not our surface

MCP config parsing of comments and trailing commas (agy reads its own `mcp_config.json`; the file `write_mcp_config` produces is one agy never reads), `/mcp` panel arrow keys, duplicate `/agents` entries, orphaned annotation files, and `/btw` under an active `/goal` — all interactive TUI or agy-side storage.

## What is NOT claimed

A version-to-version `--help` diff was not possible: no 1.1.23 capture survived, and re-running that binary to produce one would have self-updated it to 1.1.24 and destroyed the only 1.1.23 copy. **Verified instead:** all nine flags `build_argv` emits are present in 1.1.24's `--help`, and the changelog names no flag removal or rename. "Nothing else changed" is not asserted.

Both help outputs are now stored in the record (`help.txt`, `help-models.txt`) so the next run can diff against files rather than against a binary it would have to destroy.

## Tests

Pinned assertions moved with the constant, including the literal verified-release case. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.24/`

Constants and record only — no source change.
