### PR TITLE
chore(cli-version): verify agy against 1.1.25

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.24";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.25";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.24", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.25", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.25", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.23", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.25", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.26", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.24 to 1.1.25.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 253.72s |
| C — release notes | **CLEAR** |

Gate B ran against a manifest download whose sha512 was checked before it executed. The log reports only `version=1.1.25`, and the binary was byte-identical before and after (`mtime=08:14:24 size=181511808`). The machine's own agy stayed on 1.1.18.

**On the runtime:** 254s against a normal 140–175s. That is provider latency, not a regression — every test passed, and it is nothing like the 5x blowup that produced five 300s timeouts on 2026-09-03. Noted rather than glossed over, since a slow provider and a broken release fail gate B the same way.

## Gate C came from the web page — the sources swapped again

| source | covers |
| --- | --- |
| `agy changelog` from the 1.1.25 binary | 1.1.22, 1.1.23, **1.1.24** — no 1.1.25 |
| the rendered web changelog (412,268 bytes) | 1.1.23, 1.1.24, **1.1.25** ← used |

The bundled copy is a snapshot from when its build was cut, so it can lag its own binary; the web page can freeze for days. Neither is authoritative, so both are checked every run and the record says which was used.

## Nothing in 1.1.25 touches a contract we depend on

- **Gemini 3.8 Flash added to the model catalog** — additive: one more row in what `probe_models` reads. Checked rather than assumed, because the 1.1.12 TSV-column change is the standing counter-example; `models --help` is unchanged (below).
- **Markdown-defined custom agents now inherit ambient skills, rules and subagents** — does not reach us. We never pass `--agent` (no occurrence anywhere under `crates/`), and AionUi no longer creates a workspace `.agents/skills` tree (`skills.rs:9,95`).
- **"Fixed a fatal nil pointer crash … background summary updates reading cached steps after trajectory closure"** — that crash would have reached us as a turn dying without a terminal frame (the `!saw_terminal` path, `conn.rs:805`). Nothing to adopt; it removes a failure mode.
- The rest is interactive TUI (`/resume` grouping, `/skills` Windows paths, `/boost`), agy-side MCP OAuth, or Remote Control tunnelling — none of which we drive.

## Flag surface, checked against a file rather than a binary

`--help` and `models --help` are **byte-identical** 1.1.24 → 1.1.25, diffed against the captures the previous run stored in the record — not by re-running the 1.1.24 binary, which would have self-updated it away and destroyed the control.

That gap was declared openly in 1.1.24's record; storing the captures closed it on the very next run. 1.1.25's `help.txt` and `help-models.txt` are stored too.

## Tests

Pinned assertions moved with the constant, including the literal verified-release case. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.25/`

Constants and record only — no source change.
