### PR TITLE
chore(acp): bump codebuddy, dirac, grok, kilo and sigit registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.143.1"
+      "version": "2.146.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -24,7 +24,7 @@
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.5.5"
+      "version": "0.5.9"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.18"
+      "version": "1.0.21"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.5.9"
+      "version": "7.5.15"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",
@@ -58,7 +58,7 @@
     "sigit": {
       "registry_json_id": "sigit",
       "package": "@smbcloud/sigit",
-      "version": "1.5.2",
+      "version": "1.5.7",
       "skip_version_probe": true
     }
   }

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.143.1",
+                "@tencent-ai/codebuddy-code@2.146.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync, covering three days of drift (the 2026-09-05 and 09-06 runs did not execute; the state file's last checked tag was `v2026.09.03-3006ae2`). Five npx pins drifted since #966, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.143.1 → **2.146.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dirac | `dirac-cli` | 0.5.5 → **0.5.9** | ok (agentInfo dirac 0.5.9) | **succeeded** unauthenticated |
| grok | `@xai-official/grok` | 1.0.18 → **1.0.21** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.5.9 → **7.5.15** | ok (agentInfo Kilo 7.5.15) | **succeeded** unauthenticated |
| sigit | `@smbcloud/sigit` | 1.5.2 → **1.5.7** | ok (agentInfo sigit "siGit Code - AI Coding Agent" 1.5.7) | **succeeded** unauthenticated |

All five meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials. sigit carries `skip_version_probe: true`, which exempts only the runtime `--version` subprocess — it was still ACP-probed here, and that probe is what justifies the bump.

**Watch item — sigit is renaming its npm scope.** The probe's stderr carries a vendor deprecation notice: `@smbcloud/sigit is the old name for @getsigit/sigit. Both names get the same release for now`. Both names currently publish 1.5.7, and the Registry snapshot still declares `@smbcloud/sigit`, so this PR keeps the pinned package exactly as the Registry states and changes only the version. Recording it because the eventual switch is **not** a lock-only change: `agent_metadata` seeds the launch args as `["-y","@smbcloud/sigit"]` (migration 025), so moving to the new scope will need a metadata migration alongside the lock, and that PR must go to a human.

**Snapshot structural diff** (against the 2026-09-03 snapshot, the most recent one still on disk): the id set holds at 39 and every change is version churn — no distribution type was added or removed, and `args`/`env` are byte-identical for every npx entry. Non-lock movement is report-only: claude-acp 0.75.1, codex-acp 1.10.0, factory-droid 0.213.0, github-copilot-cli 1.0.83, plus new binary artifacts for cursor, goose, harn, junie, opencode, kilo's binary channel, sigit's binary channel, and `antigravity-acp` (a new `agy_acp_server` build — the deferred agent, still binary-only).

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.143.1` → `2.146.0`. All five outgoing versions were scanned across `crates/**/*.rs` with fixed-string matching before staging; codebuddy's is the only real assertion and the other four have no hits. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 6 Registry-pinned packages (autohand, deepagents, dimcode, glm-acp-agent, nova, pi) match the snapshot exactly. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.07-50f99cd`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.07-50f99cd/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
