### PR TITLE
chore(cli-version): verify agy against 1.1.27

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.25";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.27";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.25", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.25", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.27", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.27", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.24", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.26", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.26", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.28", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.25 to 1.1.27. The updater went straight from 1.1.25 to 1.1.27, so the triage covers both 1.1.26 and 1.1.27.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 224.75s |
| C — release notes | **CLEAR** — the one item on our surface was probed |

Gate B ran against a manifest download whose sha512 was checked before it executed; the log reports only `version=1.1.27`, and the binary was byte-identical before and after. 225s against a normal 140–175s is provider latency — everything passed, unlike the 5x blowup that produced five 300s timeouts on 09-03.

## The item that needed probing

> "Fixed headless runs with `-p` silently skipping tool actions they were not permitted to take, which now end with a notice naming the refused actions and report them as `denied_actions` in the JSON output."

We run `-p --output-format stream-json` and the PreToolUse hook bridge denies tools as a matter of course. **Gate B does not exercise the deny path** — the suite's only permission test is claude's — so it was probed on both paths, and they differ in a way that matters.

**agy's own gate** (omitting `--dangerously-skip-permissions` — *not* our path):

```
status: SUCCESS
denied_actions: [{"action":"write_file","display_name":"WriteToFile"}]
response: ""          <- empty
```

An empty reply with the refusal reported only in a field we do not read.

**Our path** (`--dangerously-skip-permissions` + an always-deny `.agents/hooks.json` matching what `antigravity_hook.rs::hooks_json_body` installs):

```
status: SUCCESS
denied_actions: (absent)
response: "I did not succeed because writing to out.txt was blocked by the pre-tool hook."
out.txt: not created
```

**The reply is accurate** — the agent states the refusal instead of claiming success. So `denied_actions` is emitted only on a path we never take, and it is additive regardless: `wire.rs` does not use `deny_unknown_fields`, so an unknown field cannot break deserialization.

Both captures are in the record as `probe-hook-deny.ndjson` and `probe-own-gate-deny.ndjson`.

## Loose thread, recorded rather than glossed

Neither probe produced an `error_message` step, and `translate.rs:289-292` increments `failed_steps` only on those — so `ANTIGRAVITY_STEPS_FAILED` does not fire on a hook denial, the safety net whose own comment (`wire.rs:44-46`) calls counting those steps "the only way to notice".

**Whether that is new is not established.** The comment cites an earlier observation ("four `error_message` steps, terminal SUCCESS, reply 'DONE'"), and agy cannot be A/B tested — running an older copy self-updates it. What *is* verified is that on 1.1.27 the reply is honest, which is what the notice existed to compensate for. Any change there is a source PR, not part of a bump.

## Also in our favour

> "Fixed print mode (`-p`) exiting before the session finished shutting down, which could drop the run's trailing conversation history before it reached disk."

We resume via `--conversation`, so dropped history would surface as a resumed session missing its last turn.

## Not our surface

Stricter MCP argument validation (gate B drives that path and it passed), `/model <name> <prompt>`, `/settings` verbosity text, artifact viewer scrolling, Mermaid rendering, `pickerGrouping`, Vim `?`, `/logout` speed, orphaned worktree cleanup, SQLite WAL checkpointing. The new `conversation_title` field goes to custom **status-line and window-title scripts**, not the print-mode stream — noted because a standing follow-up asks about agy-generated titles, and this is not that channel.

## Flag surface

`--help` 1.1.25 → 1.1.27 **adds** `remote-control` and removes nothing; `models --help` is byte-identical. Diffed against the captures the previous run stored, not by re-running the 1.1.25 binary. 1.1.27's captures are stored here.

## Tests

Pinned assertions moved with the constant, including the literal verified-release case. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.27/`

Constants and record only — no source change.
