### PR TITLE
chore(acp): bump dimcode and grok registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.28"
+      "version": "0.3.29"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.21"
+      "version": "1.0.22"
     },
     "kilo": {
       "registry_json_id": "kilo",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #971, each backed by a fresh serial ACP probe of the exact pinned version. This is a single-file diff: neither outgoing version appears in any test assertion, and codebuddy — the only package whose version is embedded in one — did not drift.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.28 → **0.3.29** | ok (agentInfo version 0.3.29) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 1.0.21 → **1.0.22** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials. dimcode still self-reports `agentInfo.title` as "DimAgent" against a public listing of "DimCode" — a standing vendor quirk, not an AionCore defect.

**Snapshot structural diff:** the previous snapshot (`v2026.09.07-50f99cd`, audited earlier the same day) was still on disk, so the per-agent comparison ran. Across all 39 agents the only changes are these two npx package versions — no distribution type added or removed, no `args`/`env` change anywhere, and no binary artifact movement this window. Nothing outside the lock needed reporting.

**Derived-assertion scan:** both outgoing versions (`0.3.28`, `1.0.21`) were scanned across `crates/**/*.rs` with fixed-string matching before staging; neither has a single hit. `registry_npx_lock.rs` still pins codebuddy at `2.146.0`, which is correct for this snapshot. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, kilo, nova, pi, sigit) match the snapshot exactly. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

**Standing watch (unchanged, no action in this PR):** sigit's ACP probe announced an npm scope rename (`@smbcloud/sigit` → `@getsigit/sigit`) on 2026-09-07. The Registry still declares the old scope, so the pin is untouched; the eventual switch needs a metadata migration alongside the lock, because `agent_metadata` seeds the launch args as `["-y","@smbcloud/sigit"]` (migration 025). That will be a human-reviewed PR.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.07-aafb17a`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.07-aafb17a/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 39 ids in the raw snapshot: no newly listed and no delisted agents versus the baseline. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: this is a lock version bump only; existing startup/session error paths already identify a failing agent by backend.
