### PR TITLE
chore(acp): bump codebuddy, dimcode, dirac, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.146.0"
+      "version": "2.147.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,12 +19,12 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.29"
+      "version": "0.3.30"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.5.9"
+      "version": "0.5.11"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.22"
+      "version": "1.0.24"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.5.15"
+      "version": "7.5.16"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.146.0",
+                "@tencent-ai/codebuddy-code@2.147.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Five npx pins drifted since #973, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.146.0 → **2.147.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.29 → **0.3.30** | ok (agentInfo version 0.3.30) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.5.9 → **0.5.11** | ok (agentInfo dirac 0.5.11) | **succeeded** unauthenticated |
| grok | `@xai-official/grok` | 1.0.22 → **1.0.24** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.5.15 → **7.5.16** | ok (agentInfo Kilo 7.5.16) | **succeeded** unauthenticated |

All five meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials, and every entrypoint is unchanged from the previous snapshot.

**A new agent was listed this window and is NOT part of this PR.** `kimchi` (Kimchi, https://kimchi.dev, `getkimchi/kimchi`, Apache-2.0) brings the Registry to 40 ids. It ships **binary-only** — no npx distribution exists, so it cannot enter the npx release lock at all, and binary-distribution agents are reported and deferred rather than auto-integrated. It was still validated end to end for the record: the darwin-arm64 artifact's declared sha256 matched, the archive contains no absolute or `..` paths, and running the Registry's own `./bin/kimchi --mode acp` from a temp extraction completed `initialize` (protocolVersion 1) and opened an **unauthenticated** `session/new`. Nothing was committed from that download. It is recorded as `reported-pending` for a human decision on whether AionCore wants a binary install/update path for it.

**Snapshot structural diff** (against `v2026.09.07-aafb17a`): apart from the new `kimchi` entry, every change is version churn — no distribution type added or removed on any existing agent, and `args`/`env` are byte-identical for every npx entry. Non-lock movement is report-only: factory-droid 0.215.0, gemini-cli 0.59.0, qwen-code 0.23.1, plus new binary artifacts for goose, harn, and kilo's binary channel.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.146.0` → `2.147.0`. All five outgoing versions were scanned across `crates/**/*.rs` with fixed-string matching before staging; codebuddy's is the only real assertion and the other four have no hits. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 6 Registry-pinned packages (autohand, deepagents, glm-acp-agent, nova, pi, sigit) match the snapshot exactly. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

**Standing watch (unchanged, no action here):** sigit's ACP probe announced an npm scope rename (`@smbcloud/sigit` → `@getsigit/sigit`) on 2026-09-07; the Registry still declares the old scope, so the pin is untouched. The eventual switch needs a metadata migration alongside the lock, because `agent_metadata` seeds the launch args as `["-y","@smbcloud/sigit"]` (migration 025).

## Registry snapshot

- Audit pinned to release tag [`v2026.09.09-d7007ce`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.09-d7007ce/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 40 ids in the raw snapshot: one newly listed agent (`kimchi`, binary-only, deferred as described above) and no delisted agents. (`antigravity-acp` remains listed and deferred as binary-only since 2026-08-21; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
