### PR TITLE
chore(cli-version): verify agy against 1.1.28

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.27";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.28";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,13 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.27", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.27", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.1.28", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.1.28", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.26", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.28", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("1.1.27", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.1.29", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.27 to 1.1.28.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 138.95s |
| C — release notes | **CLEAR**, with one defect on our side filed separately |

Gate B ran against a manifest download whose sha512 was checked before it executed; the log reports only `version=1.1.28`, and the binary was byte-identical before and after. The machine's own agy stayed on 1.1.18.

Gate C was read from the candidate binary — the web changelog is **frozen**, byte-identical to 2026-09-05 (md5 `d70ceaf4…`) and three releases behind.

## 1.1.28 removes several hang classes from exactly our path

Unusually much of this release lands on headless `-p`, the only way we invoke agy:

- **"Fixed headless (`-p`) runs stalling forever on implementation-plan approval that no one could give"** — we *are* that non-interactive caller.
- 503s now retry with exponential backoff instead of aborting the session.
- Finished subagents no longer appear stuck (which also left queued when-idle messages undelivered).
- A per-command memory leak that grew for the life of a session is gone.
- Fatal errors in `-p` now carry a stable `error:` marker on stderr, and runs that used to end silently now explain why.

## One item changes a terminal semantic we consume — and it is ours to fix

> "Changed what happens when `--print-timeout` expires mid-turn: the CLI now returns the partial output it has and **exits successfully** with a warning on stderr, instead of failing with a timeout error."

Probed with the prompt, the timeout and everything else pinned so only the version varies — a valid control, unlike the 09-07 case where the test picked a different model on each side:

| | 1.1.27 | 1.1.28 |
| --- | --- | --- |
| exit code | 1 | **0** |
| `result` frame | yes | yes |
| `result.status` | **ERROR** | **SUCCESS** |
| stderr | (empty) | `[agy] print timeout after 8s with turn in progress; returning partial output` |

`translate.rs:80-86` maps `SUCCESS` → `TurnOutcome::EndTurn` with `is_error = false`. So a turn that hits our one-hour `--print-timeout` is now delivered to the user as a **completed, successful turn carrying only partial output** — no error, no notice. On 1.1.27 the same turn surfaced as `Failed`.

The only signal is that stderr line, and `conn.rs:805` reads stderr only when **no** terminal frame arrived — here one does.

**Not fixed in this bump.** It needs a decision about what to do with a partial answer (surface a notice? mark the turn failed but keep the text?), which is a product call and a source change. Reproduction and both captures are in the record.

**Not a veto either.** Gate C can only block, and blocking would keep us on 1.1.27 — which still has the plan-approval stall, the stuck-subagent bug and the memory leak, all on our path. Trading several live hang classes for one rare silent truncation is the wrong way round.

## Answers a standing follow-up

> "Improved headless (`-p`) turnaround by … skipping the model call that generated a conversation title no one would see."

The open question of whether we should consume agy-generated conversation titles is now half-answered: **in headless mode agy does not generate one at all**, and the `conversation_title` added in 1.1.27 goes to status-line and window-title scripts, not our stream. Nothing on the print-mode wire to consume.

## Noted — our hook bridge may be asked more often

> "Changed the default permission for fetching URLs from always allowed to asking first."

We pass `--dangerously-skip-permissions` and gate every call ourselves, so agy's own default does not change our decisions — but URL fetches that previously never reached a permission decision may now arrive at our bridge. Recorded so a future "new permission prompts" report has a cause.

## Flag surface

`--help` and `models --help` are **byte-identical** 1.1.27 → 1.1.28, diffed against the captures stored with the previous record. 1.1.28's are stored here.

## Tests

Pinned assertions moved with the constant, including the literal verified-release case. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.1.28/`

Constants and record only — no source change.
