### PR TITLE
feat(codex): tell the user the plan tool is opt-in instead of forcing it on

### DIFF
--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -1538,7 +1538,72 @@ async fn run_backend_thinking(backend: &str) {
 /// (five sites in codex_conn.rs; claude and agy have none), and the card is
 /// pure side-channel — a turn that stops emitting plans still answers
 /// perfectly, so nothing else in this suite would notice.
+/// Whether this machine's codex will offer the `update_plan` tool at all.
+///
+/// From 0.152.0 it is opt-in (openai/codex `a9519cbc`, #41744) and AionUi
+/// deliberately does not turn it on — `-c` would override the user's own
+/// `~/.codex/config.toml`, and this is a preference rather than a compatibility
+/// requirement. So on a machine that has not enabled it there is no plan frame
+/// to assert, and failing would report an intentional product decision as a
+/// regression.
+///
+/// This is a targeted skip, not a blanket one: an operator who HAS enabled the
+/// tool still gets the full assertions, and older codex still gets them because
+/// the tool was on by default there. The only case that skips is the one where
+/// the frame genuinely cannot exist.
+///
+/// Reads the config; never writes it. Pointing codex at a throwaway `CODEX_HOME`
+/// was tried instead and abandoned — that directory also holds `auth.json`, and
+/// copying credentials into an alternate home breaks token refresh.
+fn codex_offers_plan_tool() -> Result<(), String> {
+    // Bare name on purpose: the qualification runs put the candidate first on
+    // PATH via a shim, and this must read the same binary the suite drives.
+    let version = std::process::Command::new("codex")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default();
+    // Same parser the backend uses, so "0.152.0" here means what it means there.
+    let opt_in_release = aionui_session::parse_cli_version(&version)
+        .map(|v| {
+            let mut v = v;
+            v.resize(3, 0);
+            v[..3] >= [0u32, 152, 0][..]
+        })
+        .unwrap_or(false);
+    if !opt_in_release {
+        return Ok(());
+    }
+    let home = std::env::var_os("CODEX_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")));
+    let config = home
+        .map(|h| h.join("config.toml"))
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_default();
+    // Deliberately crude: any `enabled = true` under a `[tools.update_plan]`
+    // header. A real TOML parse would be more precise, but a false NEGATIVE here
+    // only skips a test, while a false positive would fail one — so the crude
+    // check errs in the safe direction.
+    let enabled = config
+        .split('[')
+        .any(|section| section.starts_with("tools.update_plan]") && section.contains("enabled = true"));
+    if enabled {
+        Ok(())
+    } else {
+        Err(format!(
+            "codex {} makes the update_plan tool opt-in and this machine has not enabled it,              so no plan frame can exist. Add `[tools.update_plan]` / `enabled = true` to              ~/.codex/config.toml to run this test. AionUi does not set it for you (see the              CODEX_PLAN_OPT_IN notice).",
+            version.trim()
+        ))
+    }
+}
+
 async fn run_codex_plan() {
+    if let Err(why) = codex_offers_plan_tool() {
+        println!("[codex] SKIPPED live_codex_produces_a_plan: {why}");
+        return;
+    }
     let app = start_live_app().await;
     let conv_id = conversation_for(&app, "codex", "plan").await;
 

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -460,29 +460,31 @@ impl AntigravitySessionBackend {
             .unwrap_or_else(|| std::path::PathBuf::from("agy"));
         let weak = self.weak_self.get().cloned();
         tokio::spawn(async move {
-            let Some((level, message, localized)) = session_drift_notice(&spawner, "agy", &program, &session_id).await
-            else {
+            let notices = session_drift_notice(&spawner, "agy", &program, &session_id).await;
+            if notices.is_empty() {
                 return;
-            };
+            }
             if let Some(backend) = weak.and_then(|w| w.upgrade()) {
-                // Not `emit`: that drops the value when nobody is subscribed
-                // yet, which is fine for a turn frame (another one follows) but
-                // loses this notice outright — the check runs once per session.
-                crate::backend::cli_version::broadcast_notice(
-                    &backend.event_tx,
-                    SessionEnvelope {
-                        session_id: backend.session_id.clone(),
-                        turn_gen: backend.turn_gen.load(Ordering::SeqCst),
-                        event: SessionEvent::Notice {
-                            level,
-                            message,
-                            localized: Some(localized),
-                            supersedes_key: None,
+                for (level, message, localized) in notices {
+                    // Not `emit`: that drops the value when nobody is subscribed
+                    // yet, which is fine for a turn frame (another one follows) but
+                    // loses this notice outright — the check runs once per session.
+                    crate::backend::cli_version::broadcast_notice(
+                        &backend.event_tx,
+                        SessionEnvelope {
+                            session_id: backend.session_id.clone(),
+                            turn_gen: backend.turn_gen.load(Ordering::SeqCst),
+                            event: SessionEvent::Notice {
+                                level,
+                                message,
+                                localized: Some(localized),
+                                supersedes_key: None,
+                            },
                         },
-                    },
-                    "agy",
-                )
-                .await;
+                        "agy",
+                    )
+                    .await;
+                }
             }
         });
     }

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -1232,28 +1232,27 @@ impl ClaudeSessionBackend {
         let event_tx = self.event_tx.clone();
         let turn_gen = Arc::clone(&self.turn_gen);
         tokio::spawn(async move {
-            let Some((level, message, localized)) =
-                crate::backend::cli_version::session_drift_notice(&spawner, "claude", &program, &session_id).await
-            else {
-                return;
-            };
+            let notices =
+                crate::backend::cli_version::session_drift_notice(&spawner, "claude", &program, &session_id).await;
             // Retry until subscribed: a broadcast send with no receiver is
-            // discarded, and this notice has no second chance.
-            crate::backend::cli_version::broadcast_notice(
-                &event_tx,
-                SessionEnvelope {
-                    session_id: session_id.clone(),
-                    turn_gen: turn_gen.load(Ordering::SeqCst),
-                    event: SessionEvent::Notice {
-                        level,
-                        message,
-                        localized: Some(localized),
-                        supersedes_key: None,
+            // discarded, and these notices have no second chance.
+            for (level, message, localized) in notices {
+                crate::backend::cli_version::broadcast_notice(
+                    &event_tx,
+                    SessionEnvelope {
+                        session_id: session_id.clone(),
+                        turn_gen: turn_gen.load(Ordering::SeqCst),
+                        event: SessionEvent::Notice {
+                            level,
+                            message,
+                            localized: Some(localized),
+                            supersedes_key: None,
+                        },
                     },
-                },
-                "claude",
-            )
-            .await;
+                    "claude",
+                )
+                .await;
+            }
         });
     }
 

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -101,6 +101,60 @@ pub fn classify(reported: &str, verified: &str) -> VersionVerdict {
 /// direct-CLI backend instead of one pair per CLI.
 pub const CODE_CLI_VERSION_OLDER: &str = "CLI_VERSION_OLDER";
 pub const CODE_CLI_VERSION_NEWER: &str = "CLI_VERSION_NEWER";
+pub const CODE_CODEX_PLAN_OPT_IN: &str = "CODEX_PLAN_OPT_IN";
+
+/// First codex release where the `update_plan` tool became opt-in.
+///
+/// `UpdatePlanToolConfig` lost its `default = "default_true"` in openai/codex
+/// `a9519cbc` ("Make the update_plan tool opt-in", #41744); the same commit
+/// flips `"default": true` to `"default": false` under that key in the
+/// machine-generated `codex-rs/core/config.schema.json`. Re-checked against
+/// `rust-v0.153.4` on 2026-09-09: still `false`.
+const CODEX_PLAN_OPT_IN_SINCE: [u32; 3] = [0, 152, 0];
+
+/// Tell the user that codex stopped offering the plan tool by default.
+///
+/// AionUi renders the running turn's to-do list in `ConversationPlanBar`, which
+/// is fed by `SessionEvent::Plan`. From 0.152.0 the model is not offered
+/// `update_plan` unless the user enables it, so no plan frame is ever emitted
+/// and the bar simply does not appear — no error, nothing to notice.
+///
+/// AionUi deliberately does NOT force the setting on. `-c` overrides whatever
+/// the user put in their own `~/.codex/config.toml` (`codex --help`: "Override
+/// a configuration value that would otherwise be loaded from
+/// `~/.codex/config.toml`"), and this is a preference upstream made opt-in on
+/// purpose — unlike the shell-environment overrides next to it, which are
+/// compatibility requirements the host must control. Losing the bar costs a
+/// live progress view, not correctness: the turn still runs and still answers.
+///
+/// So we say so once, and leave the choice where it belongs.
+///
+/// Version-gated rather than config-gated on purpose: reading the effective
+/// value would mean an extra app-server `config/read` round-trip
+/// (`AppToolsConfig` is an untyped object in the v2 schema, so the value does
+/// come back — it is reachable, just not free). The cost of not doing it is one
+/// Info line for a user who already enabled it; the cost of doing it is a
+/// handshake on every session open.
+pub fn plan_opt_in_notice(cli: &str, reported: &str) -> Option<(NoticeLevel, String, LocalizedText)> {
+    if cli != "codex" {
+        return None;
+    }
+    let parsed = parse_version(reported)?;
+    let mut padded = parsed;
+    padded.resize(3, 0);
+    if padded[..3] < CODEX_PLAN_OPT_IN_SINCE[..] {
+        return None;
+    }
+    Some((
+        NoticeLevel::Info,
+        format!(
+            "codex {reported} no longer offers the plan tool by default, so the plan progress              bar will not appear. To bring it back, add `[tools.update_plan]` with              `enabled = true` to your codex config (~/.codex/config.toml). AionUi does not              change that file for you."
+        ),
+        LocalizedText::new(CODE_CODEX_PLAN_OPT_IN)
+            .with("cli", cli)
+            .with("reported", reported),
+    ))
+}
 
 /// The user-facing warning for a drifting install, or `None` when there is
 /// nothing worth saying.
@@ -259,33 +313,47 @@ pub fn already_reported(cli: &str, session_id: &str) -> bool {
         .insert((cli.to_owned(), session_id.to_owned()))
 }
 
-/// Probe `<cli> --version` and return the drift notice to emit, if any.
+/// Probe `<cli> --version` once and return every notice that probe justifies.
 ///
-/// Returns `None` when this session already reported, when the CLI is not
-/// version-gated, when the probe failed, or when the install matches — i.e.
-/// the caller emits whatever comes back and needs no further conditions.
+/// A list rather than an option because one version probe can now answer two
+/// questions: has the install drifted from the verified release, and does this
+/// release need the user to opt into something AionUi will not opt into for
+/// them. Both are one-shot per session and both need the same version string,
+/// so probing twice would be waste and a second `already_reported` key.
+///
+/// Empty when this session already reported, when the CLI is not version-gated,
+/// when the probe failed, or when there is simply nothing to say — i.e. the
+/// caller emits whatever comes back and needs no further conditions.
 pub async fn session_drift_notice(
     spawner: &Arc<dyn Spawner>,
     cli: &str,
     program: &std::path::Path,
     session_id: &str,
-) -> Option<(NoticeLevel, String, LocalizedText)> {
+) -> Vec<(NoticeLevel, String, LocalizedText)> {
     let Some(verified) = verified_version(cli) else {
         tracing::debug!(cli = %cli, "version check skipped: CLI is not version-gated");
-        return None;
+        return Vec::new();
     };
     if already_reported(cli, session_id) {
         tracing::debug!(session_id = %session_id, cli = %cli, "version check skipped: already reported for this session");
-        return None;
+        return Vec::new();
     }
     let Some(reported) = probe_cli_version(spawner, program, session_id).await else {
         tracing::warn!(session_id = %session_id, cli = %cli, program = %program.display(), "version probe produced no output");
-        return None;
+        return Vec::new();
     };
     tracing::info!(session_id = %session_id, cli = %cli, version = %reported, "direct CLI version detected");
-    let notice = drift_notice(cli, &reported, verified)?;
-    tracing::warn!(session_id = %session_id, cli = %cli, version = %reported, "direct CLI version drift");
-    Some(notice)
+
+    let mut notices = Vec::new();
+    if let Some(notice) = drift_notice(cli, &reported, verified) {
+        tracing::warn!(session_id = %session_id, cli = %cli, version = %reported, "direct CLI version drift");
+        notices.push(notice);
+    }
+    if let Some(notice) = plan_opt_in_notice(cli, &reported) {
+        tracing::info!(session_id = %session_id, cli = %cli, version = %reported, "codex plan tool is opt-in on this release");
+        notices.push(notice);
+    }
+    notices
 }
 
 /// How long to keep trying to hand the notice to a subscriber.
@@ -468,6 +536,39 @@ mod tests {
         assert_eq!(parse_version("2.1.220 (Claude Code)"), Some(vec![2, 1, 220]));
         assert_eq!(parse_version("codex-cli 0.144.6"), Some(vec![0, 144, 6]));
         assert_eq!(parse_version("1.1.10"), Some(vec![1, 1, 10]));
+    }
+
+    #[test]
+    fn the_plan_notice_starts_at_the_release_that_made_the_tool_opt_in() {
+        // 0.152.0 is the boundary, not an arbitrary floor: openai/codex a9519cbc
+        // ("Make the update_plan tool opt-in", #41744) is what flipped the
+        // default, and it shipped in 0.152.0.
+        assert!(plan_opt_in_notice("codex", "codex-cli 0.151.0").is_none());
+        assert!(plan_opt_in_notice("codex", "codex-cli 0.152.0").is_some());
+        assert!(plan_opt_in_notice("codex", "codex-cli 0.153.4").is_some());
+        // A future major must not fall back through the comparison.
+        assert!(plan_opt_in_notice("codex", "codex-cli 1.0.0").is_some());
+    }
+
+    #[test]
+    fn the_plan_notice_is_codex_only_and_says_what_to_do() {
+        // The other two CLIs have no such setting; a notice naming a codex
+        // config file would be nonsense in an agy or claude conversation.
+        assert!(plan_opt_in_notice("claude", "2.1.236").is_none());
+        assert!(plan_opt_in_notice("agy", "1.1.28").is_none());
+        // Unparseable output claims nothing, like every other verdict here.
+        assert!(plan_opt_in_notice("codex", "not a version").is_none());
+
+        let (level, message, localized) =
+            plan_opt_in_notice("codex", "codex-cli 0.153.4").expect("0.153.4 needs the opt-in");
+        // Info: nothing has failed, and the user may have disabled it on
+        // purpose. Same tier as the drift notices for the same reason.
+        assert_eq!(level, NoticeLevel::Info);
+        assert_eq!(localized.code, CODE_CODEX_PLAN_OPT_IN);
+        // The message must carry the fix, not just the diagnosis — this is the
+        // only place the user is told, because AionUi will not set it for them.
+        assert!(message.contains("tools.update_plan"), "{message}");
+        assert!(message.contains("config.toml"), "{message}");
     }
 
     #[test]

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -1085,28 +1085,27 @@ impl CodexSessionBackend {
         let event_tx = self.event_tx.clone();
         let turn_gen = Arc::clone(&self.turn_gen);
         tokio::spawn(async move {
-            let Some((level, message, localized)) =
-                crate::backend::cli_version::session_drift_notice(&spawner, "codex", &program, &session_id).await
-            else {
-                return;
-            };
+            let notices =
+                crate::backend::cli_version::session_drift_notice(&spawner, "codex", &program, &session_id).await;
             // Retry until subscribed: a broadcast send with no receiver is
-            // discarded, and this notice has no second chance.
-            crate::backend::cli_version::broadcast_notice(
-                &event_tx,
-                SessionEnvelope {
-                    session_id: session_id.clone(),
-                    turn_gen: turn_gen.load(std::sync::atomic::Ordering::SeqCst),
-                    event: SessionEvent::Notice {
-                        level,
-                        message,
-                        localized: Some(localized),
-                        supersedes_key: None,
+            // discarded, and these notices have no second chance.
+            for (level, message, localized) in notices {
+                crate::backend::cli_version::broadcast_notice(
+                    &event_tx,
+                    SessionEnvelope {
+                        session_id: session_id.clone(),
+                        turn_gen: turn_gen.load(std::sync::atomic::Ordering::SeqCst),
+                        event: SessionEvent::Notice {
+                            level,
+                            message,
+                            localized: Some(localized),
+                            supersedes_key: None,
+                        },
                     },
-                },
-                "codex",
-            )
-            .await;
+                    "codex",
+                )
+                .await;
+            }
         });
     }
 


### PR DESCRIPTION
Replaces #961. codex 0.152.0 made the `update_plan` tool opt-in; this tells the user rather than overriding their config.

## What changed upstream

`UpdatePlanToolConfig` lost its `default = "default_true"` — openai/codex `a9519cbc`, *"Make the update_plan tool opt-in"* (#41744). The same commit flips the default under that key in the generated `codex-rs/core/config.schema.json`. Re-checked against `rust-v0.153.4` on 2026-09-09: still `false`.

The model is never offered the tool, no plan notification is emitted, and `ConversationPlanBar` renders **nothing at all** (it returns null when there are no entries) — so there is no error and nothing for the user to notice.

## Why #961's approach was wrong

#961 passed `-c tools.update_plan.enabled=true` when spawning the app-server. `codex --help` is explicit about what that does:

> `-c, --config <key=value>` — Override a configuration value that would otherwise be loaded from `~/.codex/config.toml`

So it silently overrides a user who turned the tool off on purpose. It is also not the same kind of setting as the two overrides beside it — `shell_environment_policy.inherit=all` / `include_only=[]` are compatibility requirements the host must control; `update_plan` is a preference upstream made opt-in deliberately.

And the stake is smaller than #961 claimed: what is lost is a **live progress view**, not correctness. The turn still runs and still answers. #961's "the plan card stays permanently empty" was also inaccurate — the bar does not appear at all.

## What this does instead

One Info notice, once per session, when the detected codex is ≥ 0.152.0, naming the setting and the file. `session_drift_notice` now returns every notice a single version probe justifies instead of at most one: both are one-shot per session and both need the same version string, so probing twice would be waste and a second `already_reported` key.

**Version-gated, not config-gated, on purpose.** Reading the effective value means an extra app-server `config/read` round-trip — `AppToolsConfig` is an untyped object in the v2 schema, so the value *does* come back; it is reachable, just not free. The cost of not reading it is one Info line for someone who already enabled the tool; the cost of reading it is a handshake on every session open. Happy to switch if that trade looks wrong.

## The live test: a targeted skip (second commit)

`live_codex_produces_a_plan` asserts a plan frame, which cannot exist on 0.152+ unless the user opted in — so on such a machine it was reporting an intentional product decision as a regression.

The guard skips **only** when both are true: codex ≥ 0.152.0 **and** this machine's config does not enable the tool. An operator who has enabled it still gets the full assertions; older codex still gets them because the tool was on by default. The skip message names the setting, the file, and why AionUi will not write it.

All three branches verified against real binaries:

| codex | tool | result |
| --- | --- | --- |
| 0.153.4 | not enabled | **SKIPPED** in 0.11s, with the explanation |
| 0.151.0 | on by default | **runs**, `FRAME-TYPES` includes `plan`, ok in 28.63s |
| 0.153.4 | config enables it | **does not skip** (0 SKIPPED lines) |

Version parsing goes through `aionui_session::parse_cli_version`, so `0.152.0` means the same here as in the backend. The config check is deliberately crude — any `enabled = true` under a `[tools.update_plan]` header — because a false negative only skips a test while a false positive would fail one.

**Coverage cost, stated plainly:** on a machine with the tool off, the codex plan translation path (plan notification → `SessionEvent::Plan` → `ConversationPlanBar`) is no longer exercised. Enabling the tool locally restores it.

### An approach that was tried and abandoned

Pointing the test at a throwaway `CODEX_HOME` seeded with the setting. That directory also holds `auth.json`, and copying credentials into an alternate home breaks token refresh:

```
ERROR: Your access token could not be refreshed because you have since logged out
       or signed in to another account. Please sign in again.
```

The operator's real login was verified intact afterwards and the change reverted rather than shipped unverified. The guard that shipped only **reads** the config; it never writes it.

## Tests

`cargo test -p aionui-session --lib`: `cli_version` 16/16 (two new: the 0.152.0 boundary, and that the notice is codex-only and carries the fix rather than just the diagnosis), `codex_conn` 145/145, `antigravity` 111/111. Clippy clean on both crates, fmt clean.

## AionUi side

The notice ships an English fallback string, so it works untranslated. Localising it needs a `conversation.agentTip.codes.CODEX_PLAN_OPT_IN.body` entry in AionUi.

Source change — left for human review, no auto-merge.
