### PR TITLE
fix(conversation): rebuild agent runtime after workspace changes

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -65,6 +65,7 @@ impl CloseReason {
                 Some(AgentKillReason::RuntimeCapabilityChanged) => {
                     "Agent killed: runtime capability changed".to_owned()
                 }
+                Some(AgentKillReason::WorkspaceChanged) => "Agent killed: workspace changed".to_owned(),
                 Some(AgentKillReason::SessionRevoked) => "Agent killed: session revoked".to_owned(),
                 Some(AgentKillReason::Archived) => "Agent killed: archived".to_owned(),
                 None => "Agent killed".to_owned(),
@@ -426,6 +427,13 @@ mod tests {
             }
             .user_facing_message(),
             "Agent killed: conversation deleted"
+        );
+        assert_eq!(
+            CloseReason::Killed {
+                reason: Some(AgentKillReason::WorkspaceChanged)
+            }
+            .user_facing_message(),
+            "Agent killed: workspace changed"
         );
         assert_eq!(
             CloseReason::Killed { reason: None }.user_facing_message(),

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -124,8 +124,10 @@ impl WorkerTaskManagerImpl {
             .and_then(|slot| slot.get().map(|managed| managed.agent.clone()))
     }
 
-    fn initialised_managed_task(&self, conversation_id: &str) -> Option<ManagedAgentTask> {
-        self.tasks.get(conversation_id).and_then(|slot| slot.get().cloned())
+    fn initialised_managed_task(&self, conversation_id: &str) -> Option<(TaskSlot, ManagedAgentTask)> {
+        let slot = self.tasks.get(conversation_id).map(|entry| Arc::clone(entry.value()))?;
+        let managed = slot.get()?.clone();
+        Some((slot, managed))
     }
 
     fn invalidate_runtime_tokens(&self, conversation_id: &str) {
@@ -171,14 +173,40 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
         conversation_id: &str,
         mut options: BuildTaskOptions,
     ) -> Result<AgentInstance, AgentError> {
-        if let Some(existing) = self.initialised_managed_task(conversation_id)
-            && !existing.runtime_capabilities.satisfies(&options.runtime_capabilities)
-        {
-            info!(
-                conversation_id,
-                "Rebuilding agent task because runtime capabilities changed"
-            );
-            self.kill(conversation_id, Some(AgentKillReason::RuntimeCapabilityChanged))?;
+        let rebuild = self
+            .initialised_managed_task(conversation_id)
+            .and_then(|(slot, existing)| {
+                let reason = if !existing.runtime_capabilities.satisfies(&options.runtime_capabilities) {
+                    Some(AgentKillReason::RuntimeCapabilityChanged)
+                } else if existing.agent.workspace() != options.context.workspace.path.as_str() {
+                    Some(AgentKillReason::WorkspaceChanged)
+                } else {
+                    None
+                }?;
+                Some((slot, reason))
+            });
+
+        if let Some((stale_slot, reason)) = rebuild {
+            // Remove only the slot that was inspected. Another concurrent
+            // caller may already have replaced it with the correct task.
+            if let Some((id, removed_slot)) = self
+                .tasks
+                .remove_if(conversation_id, |_, current| Arc::ptr_eq(current, &stale_slot))
+            {
+                self.invalidate_runtime_tokens(&id);
+                info!(
+                    conversation_id = %id,
+                    ?reason,
+                    "Rebuilding agent task because runtime context changed"
+                );
+                if let Some(managed) = removed_slot.get() {
+                    managed.agent.kill(Some(reason))?;
+                }
+            }
+
+            // A workspace rebuild is also a new task generation. Refresh even
+            // if a concurrent caller removed the stale slot first; the options
+            // are used only if this caller wins initialization of the new slot.
             self.refresh_runtime_token_for_new_task(&mut options);
         }
 
@@ -437,6 +465,11 @@ mod tests {
             self
         }
 
+        fn with_workspace(mut self, workspace: impl Into<String>) -> Self {
+            self.workspace = workspace.into();
+            self
+        }
+
         fn with_last_activity(mut self, ts: TimestampMs) -> Self {
             self.last_activity = AtomicI64::new(ts);
             self
@@ -541,6 +574,12 @@ mod tests {
         options
     }
 
+    fn with_workspace(mut options: BuildTaskOptions, workspace: &str) -> BuildTaskOptions {
+        options.context.workspace.path = workspace.to_owned();
+        options.context.workspace.stored_path = workspace.to_owned();
+        options
+    }
+
     fn mock_instance(agent: MockAgent) -> AgentInstance {
         AgentInstance::Mock(Arc::new(agent))
     }
@@ -554,7 +593,13 @@ mod tests {
 
     fn make_manager() -> WorkerTaskManagerImpl {
         let factory: AgentFactory = Arc::new(|opts: BuildTaskOptions| {
-            async move { Ok(mock_instance(MockAgent::new(opts.conversation_id(), None))) }.boxed()
+            async move {
+                let workspace = opts.context.workspace.path.clone();
+                Ok(mock_instance(
+                    MockAgent::new(opts.conversation_id(), None).with_workspace(workspace),
+                ))
+            }
+            .boxed()
         });
         WorkerTaskManagerImpl::new(factory)
     }
@@ -640,6 +685,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_or_build_rebuilds_when_requested_workspace_changes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_factory = Arc::clone(&calls);
+        let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
+            let calls = Arc::clone(&calls_for_factory);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let workspace = opts.context.workspace.path.clone();
+                Ok(mock_instance(
+                    MockAgent::new(opts.conversation_id(), None).with_workspace(workspace),
+                ))
+            }
+            .boxed()
+        });
+        let mgr = WorkerTaskManagerImpl::new(factory);
+
+        let old = mgr
+            .get_or_build_task("conv-1", with_workspace(make_options("conv-1"), "/tmp/workspace-a"))
+            .await
+            .unwrap();
+        let new = mgr
+            .get_or_build_task("conv-1", with_workspace(make_options("conv-1"), "/tmp/workspace-b"))
+            .await
+            .unwrap();
+
+        assert!(!same_mock(&old, &new));
+        assert_eq!(new.workspace(), "/tmp/workspace-b");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(mgr.active_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_or_build_reuses_task_when_requested_workspace_is_unchanged() {
+        let mgr = make_manager();
+        let options = with_workspace(make_options("conv-1"), "/tmp/workspace-a");
+        let old = mgr.get_or_build_task("conv-1", options.clone()).await.unwrap();
+        let reused = mgr.get_or_build_task("conv-1", options).await.unwrap();
+
+        assert!(same_mock(&old, &reused));
+        assert_eq!(mgr.active_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn workspace_and_capability_change_rebuilds_only_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let killed = Arc::new(AtomicUsize::new(0));
+        let factory: AgentFactory = Arc::new({
+            let calls = Arc::clone(&calls);
+            let killed = Arc::clone(&killed);
+            move |opts: BuildTaskOptions| {
+                let calls = Arc::clone(&calls);
+                let killed = Arc::clone(&killed);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let workspace = opts.context.workspace.path.clone();
+                    Ok(mock_instance(
+                        MockAgent::new(opts.conversation_id(), None)
+                            .with_workspace(workspace)
+                            .with_kill_counter(killed),
+                    ))
+                }
+                .boxed()
+            }
+        });
+        let mgr = WorkerTaskManagerImpl::new(factory);
+        mgr.get_or_build_task("conv-1", with_workspace(make_options("conv-1"), "/tmp/workspace-a"))
+            .await
+            .unwrap();
+
+        let mut changed = with_workspace(make_options("conv-1"), "/tmp/workspace-b");
+        changed.runtime_capabilities.conversation_runtime_context_version = Some(CONVERSATION_RUNTIME_CONTEXT_VERSION);
+        let rebuilt = mgr.get_or_build_task("conv-1", changed).await.unwrap();
+
+        assert_eq!(rebuilt.workspace(), "/tmp/workspace-b");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(killed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn get_or_build_rebuilds_when_existing_task_lacks_requested_runtime_context_capability() {
         let mgr = make_manager();
         let h1 = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
@@ -717,6 +845,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workspace_rebuild_refreshes_runtime_token_after_killing_existing_task() {
+        let runtime_tokens = Arc::new(RuntimeTokenService::new());
+        let old_issue = runtime_tokens.issue(
+            "user-1",
+            "conv-1",
+            TEAM_RUNTIME_TOKEN_SESSION_GENERATION,
+            [RuntimeTokenScope::TeamContext, RuntimeTokenScope::TeamCall],
+        );
+        let observed_tokens = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let factory: AgentFactory = Arc::new({
+            let observed_tokens = Arc::clone(&observed_tokens);
+            move |opts: BuildTaskOptions| {
+                let observed_tokens = Arc::clone(&observed_tokens);
+                async move {
+                    if let Some((_, token)) = opts
+                        .context
+                        .runtime_env
+                        .iter()
+                        .find(|(key, _)| key == AIONUI_RUNTIME_TOKEN_ENV)
+                    {
+                        observed_tokens.lock().unwrap().push(token.clone());
+                    }
+                    let workspace = opts.context.workspace.path.clone();
+                    Ok(mock_instance(
+                        MockAgent::new(opts.conversation_id(), None).with_workspace(workspace),
+                    ))
+                }
+                .boxed()
+            }
+        });
+        let mgr = WorkerTaskManagerImpl::new(factory).with_runtime_token_service(Arc::clone(&runtime_tokens));
+        let old = mgr
+            .get_or_build_task(
+                "conv-1",
+                with_workspace(
+                    make_team_options_with_runtime_token("conv-1", &old_issue.token),
+                    "/tmp/workspace-a",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let new = mgr
+            .get_or_build_task(
+                "conv-1",
+                with_workspace(
+                    make_team_options_with_runtime_token("conv-1", &old_issue.token),
+                    "/tmp/workspace-b",
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert!(!same_mock(&old, &new));
+        assert_eq!(new.workspace(), "/tmp/workspace-b");
+        let tokens = observed_tokens.lock().unwrap().clone();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0], old_issue.token);
+        assert_ne!(tokens[1], old_issue.token);
+        assert_eq!(
+            runtime_tokens.validate(
+                Some(&old_issue.token),
+                "user-1",
+                "conv-1",
+                RuntimeTokenScope::TeamCall,
+                TEAM_RUNTIME_TOKEN_SESSION_GENERATION,
+            ),
+            Err(RuntimeTokenError::Unknown)
+        );
+        runtime_tokens
+            .validate(
+                Some(&tokens[1]),
+                "user-1",
+                "conv-1",
+                RuntimeTokenScope::TeamCall,
+                TEAM_RUNTIME_TOKEN_SESSION_GENERATION,
+            )
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn get_or_build_is_single_flight_under_concurrency() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -752,6 +961,57 @@ mod tests {
         assert_eq!(mgr.active_count(), 1);
         for h in handles.iter().skip(1) {
             assert!(same_mock(&handles[0], h), "all callers see the same handle");
+        }
+    }
+
+    #[tokio::test]
+    async fn workspace_rebuild_is_single_flight_under_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_factory = Arc::clone(&calls);
+        let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
+            let calls = Arc::clone(&calls_for_factory);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                let workspace = opts.context.workspace.path.clone();
+                Ok(mock_instance(
+                    MockAgent::new(opts.conversation_id(), None).with_workspace(workspace),
+                ))
+            }
+            .boxed()
+        });
+        let mgr = Arc::new(WorkerTaskManagerImpl::new(factory));
+        mgr.get_or_build_task(
+            "conv-race",
+            with_workspace(make_options("conv-race"), "/tmp/workspace-a"),
+        )
+        .await
+        .unwrap();
+
+        let mut joins = Vec::new();
+        for _ in 0..10 {
+            let mgr = Arc::clone(&mgr);
+            joins.push(tokio::spawn(async move {
+                mgr.get_or_build_task(
+                    "conv-race",
+                    with_workspace(make_options("conv-race"), "/tmp/workspace-b"),
+                )
+                .await
+            }));
+        }
+        let handles: Vec<_> = futures_util::future::join_all(joins)
+            .await
+            .into_iter()
+            .map(|result| result.unwrap().unwrap())
+            .collect();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "only one replacement may be built");
+        assert_eq!(mgr.active_count(), 1);
+        assert_eq!(handles[0].workspace(), "/tmp/workspace-b");
+        for handle in handles.iter().skip(1) {
+            assert!(same_mock(&handles[0], handle), "all callers must share the replacement");
         }
     }
 

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -142,6 +142,7 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
         Box::pin(async move {
             Ok(AgentInstance::Mock(std::sync::Arc::new(NoopMockAgent {
                 conversation_id: opts.conversation_id().to_owned(),
+                workspace: opts.context.workspace.path.clone(),
             })))
         })
     });
@@ -157,6 +158,7 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
 
 struct NoopMockAgent {
     conversation_id: String,
+    workspace: String,
 }
 
 #[async_trait::async_trait]
@@ -168,7 +170,7 @@ impl IAgentTask for NoopMockAgent {
         &self.conversation_id
     }
     fn workspace(&self) -> &str {
-        "/tmp/test"
+        &self.workspace
     }
     fn status(&self) -> Option<aionui_common::ConversationStatus> {
         None

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -805,6 +805,111 @@ async fn t2_1b_send_message_legacy_workspace_with_whitespace_succeeds() {
 }
 
 #[tokio::test]
+async fn workspace_move_patch_keeps_two_message_turns_on_new_workspace() {
+    let (mut app, services) = build_app_with_mock_agents().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let dir = tempfile::tempdir().unwrap();
+    let workspace_a = dir.path().join("workspace-a");
+    let workspace_b = dir.path().join("workspace-b");
+    std::fs::create_dir(&workspace_a).unwrap();
+
+    let create = common::json_with_token(
+        "POST",
+        "/api/conversations",
+        json!({
+            "type": "acp",
+            "name": "Moved Workspace",
+            "extra": {
+                "backend": "gemini",
+                "workspace": workspace_a.to_string_lossy()
+            }
+        }),
+        &token,
+        &csrf,
+    );
+    let create_response = app.clone().oneshot(create).await.unwrap();
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_json = body_json(create_response).await;
+    let conv_id = create_json["data"]["id"].as_str().unwrap().to_owned();
+    let owner_user_id = services
+        .conversation_repo
+        .owner_user_id(&conv_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let ensure = common::json_with_token(
+        "POST",
+        &format!("/api/conversations/{conv_id}/runtime/ensure"),
+        json!({}),
+        &token,
+        &csrf,
+    );
+    let ensure_response = app.clone().oneshot(ensure).await.unwrap();
+    assert_eq!(ensure_response.status(), StatusCode::OK);
+    assert_eq!(
+        services.worker_task_manager.get_task(&conv_id).unwrap().workspace(),
+        workspace_a.to_string_lossy()
+    );
+
+    std::fs::rename(&workspace_a, &workspace_b).unwrap();
+    let patch = common::json_with_token(
+        "PATCH",
+        &format!("/api/conversations/{conv_id}"),
+        json!({ "extra": { "workspace": workspace_b.to_string_lossy() } }),
+        &token,
+        &csrf,
+    );
+    let patch_response = app.clone().oneshot(patch).await.unwrap();
+    assert_eq!(patch_response.status(), StatusCode::OK);
+    assert!(services.worker_task_manager.get_task(&conv_id).is_none());
+
+    for content in ["first turn after move", "second turn after move"] {
+        let send = common::json_with_token(
+            "POST",
+            &format!("/api/conversations/{conv_id}/messages"),
+            json!({ "content": content }),
+            &token,
+            &csrf,
+        );
+        let send_response = app.clone().oneshot(send).await.unwrap();
+        assert_eq!(send_response.status(), StatusCode::ACCEPTED);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            services.conversation_runtime_state.wait_until_unclaimed(&conv_id),
+        )
+        .await
+        .expect("mock turn should complete");
+
+        let row = services
+            .conversation_repo
+            .get(&owner_user_id, &conv_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+        assert_eq!(extra["workspace"], workspace_b.to_string_lossy().to_string());
+        assert_eq!(
+            services.worker_task_manager.get_task(&conv_id).unwrap().workspace(),
+            workspace_b.to_string_lossy()
+        );
+    }
+
+    let messages = app
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    let messages_json = body_json(messages).await;
+    assert!(
+        !messages_json.to_string().contains("WORKSPACE_PATH_RUNTIME_UNAVAILABLE"),
+        "moved workspace must remain usable across both turns"
+    );
+}
+
+#[tokio::test]
 async fn t2_1c_send_message_missing_workspace_persists_message_and_failure_tip() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -288,6 +288,9 @@ pub enum AgentKillReason {
     /// The requested runtime capabilities changed, so the in-memory task must
     /// be rebuilt before handling the next turn.
     RuntimeCapabilityChanged,
+    /// The requested workspace differs from the cached agent workspace, so the
+    /// in-memory task must be rebuilt before handling the next turn.
+    WorkspaceChanged,
     /// The owning user's Core session was revoked, so foreground runtime state
     /// and agent processes for that user must be torn down.
     SessionRevoked,

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2332,24 +2332,37 @@ impl ConversationService {
 
         let now = now_ms();
 
+        let existing_extra_value: serde_json::Value =
+            serde_json::from_str(&existing.extra).unwrap_or_else(|_| serde_json::json!({}));
+        let old_workspace = existing_extra_value
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let mut workspace_changed = false;
+
         // Merge extra if provided. For aionrs, strip `extra.model` post-merge
         // so the row keeps a single canonical model source (top-level column).
         let merged_extra = if let Some(new_extra) = &req.extra {
-            let mut existing_extra: serde_json::Value =
-                serde_json::from_str(&existing.extra).unwrap_or_else(|_| serde_json::json!({}));
-            merge_json(&mut existing_extra, new_extra);
-            strip_request_owner_user_id(&mut existing_extra);
+            let mut merged = existing_extra_value;
+            merge_json(&mut merged, new_extra);
+            strip_request_owner_user_id(&mut merged);
             if existing_type == AgentType::Aionrs
-                && let Some(obj) = existing_extra.as_object_mut()
+                && let Some(obj) = merged.as_object_mut()
                 && obj.remove("model").is_some()
             {
                 warn!("aionrs update: stripped legacy `extra.model` from merged extra");
             }
             if new_extra.get("workspace").is_some() {
-                normalize_workspace_extra(&mut existing_extra)?;
+                normalize_workspace_extra(&mut merged)?;
+                let new_workspace = merged
+                    .get("workspace")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                workspace_changed = old_workspace != new_workspace;
             }
             Some(
-                serde_json::to_string(&existing_extra)
+                serde_json::to_string(&merged)
                     .map_err(|e| ConversationError::internal(format!("Failed to serialize merged extra: {e}")))?,
             )
         } else {
@@ -2421,13 +2434,22 @@ impl ConversationService {
             .await?;
         }
 
-        if model_changed {
+        let should_rebuild_task = workspace_changed || model_changed;
+        let kill_reason = workspace_changed.then_some(AgentKillReason::WorkspaceChanged);
+        if should_rebuild_task {
             info!(
-                model_changed = true,
-                "Conversation updated, killing agent task due to model change"
+                conversation_id = %id,
+                model_changed,
+                workspace_changed,
+                ?kill_reason,
+                "Conversation runtime context changed; recycling agent task"
             );
-            if let Err(e) = task_manager.kill(id, None) {
-                warn!(error = %ErrorChain(&e), "Failed to kill agent after model change");
+            if let Err(e) = task_manager.kill(id, kill_reason) {
+                warn!(
+                    conversation_id = %id,
+                    error = %ErrorChain(&e),
+                    "Failed to recycle agent after conversation update"
+                );
             }
         }
 
@@ -4911,7 +4933,10 @@ impl ConversationService {
         stored_workspace: &str,
         resolved_workspace: &str,
     ) -> Result<(), ConversationError> {
-        if resolved_workspace.is_empty() || resolved_workspace == stored_workspace {
+        // Only a strictly empty legacy workspace may be filled automatically.
+        // A non-empty value is user-owned even when it is malformed or differs
+        // from the path reported by a cached agent.
+        if !stored_workspace.is_empty() || resolved_workspace.is_empty() {
             return Ok(());
         }
         if !self
@@ -4921,7 +4946,8 @@ impl ConversationService {
             return Ok(());
         }
 
-        // Fetch latest extra, merge the resolved workspace path in, and persist.
+        // The user may have selected a workspace after the caller captured its
+        // snapshot, so re-read the row immediately before persisting.
         let row = self
             .conversation_repo
             .get(user_id, conversation_id)
@@ -4929,6 +4955,14 @@ impl ConversationService {
             .ok_or_else(|| ConversationError::internal("Conversation vanished during workspace sync"))?;
 
         let mut extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
+        let latest_workspace = extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if !latest_workspace.is_empty() {
+            return Ok(());
+        }
+
         extra["workspace"] = serde_json::Value::String(resolved_workspace.to_owned());
 
         let extra_json = serde_json::to_string(&extra)
@@ -4941,11 +4975,7 @@ impl ConversationService {
         };
         self.conversation_repo.update(user_id, conversation_id, &update).await?;
 
-        debug!(
-            conversation_id,
-            workspace = resolved_workspace,
-            "Persisted auto-resolved workspace to conversation.extra"
-        );
+        debug!(conversation_id, "Persisted legacy auto-resolved workspace");
         Ok(())
     }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -2610,6 +2610,115 @@ async fn update_extra_merge() {
 }
 
 #[tokio::test]
+async fn update_workspace_recycles_agent_once_with_workspace_changed_reason() {
+    let task = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo) = make_service_with_mock_task_manager(Arc::clone(&task));
+    let task_manager: Arc<dyn IWorkerTaskManager> = task.clone();
+    let dir = tempfile::tempdir().unwrap();
+    let old_workspace = dir.path().join("workspace-a");
+    let new_workspace = dir.path().join("workspace-b");
+    std::fs::create_dir_all(&old_workspace).unwrap();
+    std::fs::create_dir_all(&new_workspace).unwrap();
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": old_workspace.to_string_lossy() }
+    }))
+    .unwrap();
+    let conversation = svc.create("user_1", create_req).await.unwrap();
+
+    let update_req: UpdateConversationRequest = serde_json::from_value(json!({
+        "extra": { "workspace": new_workspace.to_string_lossy() }
+    }))
+    .unwrap();
+    svc.update("user_1", &conversation.id, update_req, &task_manager)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        task.kill_records(),
+        vec![(conversation.id, Some(AgentKillReason::WorkspaceChanged))]
+    );
+}
+
+#[tokio::test]
+async fn update_same_workspace_does_not_recycle_agent() {
+    let task = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo) = make_service_with_mock_task_manager(Arc::clone(&task));
+    let task_manager: Arc<dyn IWorkerTaskManager> = task.clone();
+    let workspace = ensure_test_workspace_path();
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": workspace }
+    }))
+    .unwrap();
+    let conversation = svc.create("user_1", create_req).await.unwrap();
+
+    let update_req: UpdateConversationRequest = serde_json::from_value(json!({
+        "extra": { "workspace": workspace }
+    }))
+    .unwrap();
+    svc.update("user_1", &conversation.id, update_req, &task_manager)
+        .await
+        .unwrap();
+
+    assert!(task.kill_records().is_empty());
+}
+
+#[tokio::test]
+async fn update_without_workspace_or_model_does_not_recycle_agent() {
+    let task = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo) = make_service_with_mock_task_manager(Arc::clone(&task));
+    let task_manager: Arc<dyn IWorkerTaskManager> = task.clone();
+    let conversation = svc.create("user_1", make_create_req()).await.unwrap();
+
+    for update in [
+        json!({ "name": "renamed" }),
+        json!({ "pinned": true }),
+        json!({ "extra": { "contextFileName": "context.md" } }),
+    ] {
+        let request: UpdateConversationRequest = serde_json::from_value(update).unwrap();
+        svc.update("user_1", &conversation.id, request, &task_manager)
+            .await
+            .unwrap();
+    }
+
+    assert!(task.kill_records().is_empty());
+}
+
+#[tokio::test]
+async fn update_workspace_and_model_recycles_agent_only_once() {
+    let task = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo) = make_service_with_mock_task_manager(Arc::clone(&task));
+    let task_manager: Arc<dyn IWorkerTaskManager> = task.clone();
+    let dir = tempfile::tempdir().unwrap();
+    let old_workspace = dir.path().join("workspace-a");
+    let new_workspace = dir.path().join("workspace-b");
+    std::fs::create_dir_all(&old_workspace).unwrap();
+    std::fs::create_dir_all(&new_workspace).unwrap();
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "aionrs",
+        "model": { "provider_id": "provider-1", "model": "model-a" },
+        "extra": { "workspace": old_workspace.to_string_lossy() }
+    }))
+    .unwrap();
+    let conversation = svc.create("user_1", create_req).await.unwrap();
+
+    let update_req: UpdateConversationRequest = serde_json::from_value(json!({
+        "model": { "provider_id": "provider-1", "model": "model-b" },
+        "extra": { "workspace": new_workspace.to_string_lossy() }
+    }))
+    .unwrap();
+    svc.update("user_1", &conversation.id, update_req, &task_manager)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        task.kill_records(),
+        vec![(conversation.id, Some(AgentKillReason::WorkspaceChanged))]
+    );
+}
+
+#[tokio::test]
 async fn update_model() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let workspace = ensure_test_workspace_path();
@@ -6302,6 +6411,80 @@ async fn send_message_persists_factory_resolved_workspace() {
     .await
     .expect("factory-resolved workspace should be persisted in the background");
     assert_eq!(updated.extra["workspace"], auto_workspace);
+}
+
+#[tokio::test]
+async fn maybe_persist_workspace_does_not_replace_non_empty_snapshot() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conversation = svc.create("user_1", make_create_req()).await.unwrap();
+    let saved_workspace = "saved-workspace-b";
+    repo.update(
+        "user_1",
+        &conversation.id,
+        &ConversationRowUpdate {
+            extra: Some(json!({ "workspace": saved_workspace }).to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    svc.maybe_persist_workspace("user_1", &conversation.id, saved_workspace, "cached-workspace-a")
+        .await
+        .unwrap();
+
+    let row = repo.get("user_1", &conversation.id).await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+    assert_eq!(extra["workspace"], saved_workspace);
+}
+
+#[tokio::test]
+async fn maybe_persist_workspace_rechecks_latest_database_value() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conversation = svc.create("user_1", make_create_req()).await.unwrap();
+    let saved_workspace = "saved-workspace-b";
+    repo.update(
+        "user_1",
+        &conversation.id,
+        &ConversationRowUpdate {
+            extra: Some(json!({ "workspace": saved_workspace }).to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    svc.maybe_persist_workspace("user_1", &conversation.id, "", "cached-workspace-a")
+        .await
+        .unwrap();
+
+    let row = repo.get("user_1", &conversation.id).await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+    assert_eq!(extra["workspace"], saved_workspace);
+}
+
+#[tokio::test]
+async fn maybe_persist_workspace_fills_empty_legacy_value() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conversation = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.update(
+        "user_1",
+        &conversation.id,
+        &ConversationRowUpdate {
+            extra: Some(json!({ "workspace": "" }).to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    svc.maybe_persist_workspace("user_1", &conversation.id, "", "factory-workspace")
+        .await
+        .unwrap();
+
+    let row = repo.get("user_1", &conversation.id).await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+    assert_eq!(extra["workspace"], "factory-workspace");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fix stale agent runtime reuse after a conversation workspace is changed or moved.

Previously, updating `conversation.extra.workspace` could leave the in-memory agent bound to the old workspace. Runtime workspace persistence could also overwrite a newly selected non-empty workspace with a stale resolved path.

## Changes

- Detect normalized workspace changes during conversation updates and recycle the cached agent with an explicit `WorkspaceChanged` reason.
- Defensively compare the cached agent workspace with the requested workspace in the task manager.
- Use identity-checked slot removal and single-flight initialization so concurrent rebuild requests create only one replacement agent.
- Invalidate and refresh runtime tokens when rebuilding the task.
- Restrict automatic workspace persistence to empty legacy values and re-read the latest database row before writing.
- Add unit, integration, concurrency, token-rotation, and directory-move E2E coverage.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p aionui-common -p aionui-ai-agent -p aionui-conversation -p aionui-app -- -D warnings`
- `cargo test -p aionui-ai-agent task_manager::tests --lib`
- New conversation workspace tests (7)
- `cargo test -p aionui-app --test message_e2e workspace_move_patch_keeps_two_message_turns_on_new_workspace -- --exact`
- `just push` (9,262/9,262 selected tests passed locally; verified upstream Windows-incompatible tests were excluded only by an untracked local nextest profile, while CI retains the repository configuration)

## Observability

Existing structured lifecycle logging was extended with conversation ID, change flags, and rebuild reason. Workspace paths are intentionally not logged.