### PR TITLE
chore(acp): bump dimcode and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.30"
+      "version": "0.3.32"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.37"
+      "version": "1.1.38"
     },
     "pi": {
       "registry_json_id": "pi-acp",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #974, each backed by a fresh serial ACP probe of the exact pinned version. This is a single-file diff: neither outgoing version appears in any test assertion, and codebuddy — the only package whose version is embedded in one — did not drift.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.30 → **0.3.32** | ok (agentInfo version 0.3.32) | auth required (`-32000`, "Provider credentials are required") |
| nova | `@compass-ai/nova` | 1.1.37 → **1.1.38** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", with a `kore-terminal-auth` terminal auth method attached) |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication/configuration requirement. nova's error carries an explicit `authMethods` payload, which is the classifiable-config case rather than an unclassified protocol error. Probes ran serially with no inherited HOME or credentials, and both entrypoints (`acp`) are unchanged.

Two standing vendor quirks reconfirmed, neither an AionCore defect and neither changing metadata: nova self-reports `agentInfo` as `kore-cli 1.0.0` rather than its package identity, and dimcode reports `agentInfo.title` "DimAgent" against a public listing of "DimCode".

**Snapshot structural diff** (against `v2026.09.09-d7007ce`, audited earlier the same day): the id set holds at 40 and every change is version churn — no distribution type added or removed, and `args`/`env` are byte-identical for every npx entry. Non-lock movement is report-only: factory-droid 0.215.1, qwen-code 0.23.2, plus new binary artifacts for harn, opencode, and kimchi.

**Derived-assertion scan:** both outgoing versions (`0.3.30`, `1.1.37`) were scanned across `crates/**/*.rs` with fixed-string matching before staging; neither has a single hit. `registry_npx_lock.rs` still pins codebuddy at `2.147.0`, correct for this snapshot. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, grok, kilo, pi, sigit) match the snapshot exactly. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

**Standing watches (unchanged, no action in this PR):**
- `kimchi` (listed 2026-09-09) stays deferred — binary-only, so it cannot enter the npx release lock; its binary artifact moved again this window. Integrating it needs a binary install/update path plus a seed migration, which is a human-reviewed change.
- sigit's npm scope rename (`@smbcloud/sigit` → `@getsigit/sigit`) is still only a vendor stderr notice; the Registry declares the old scope, so the pin is untouched.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.09-cfa1ca8`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.09-cfa1ca8/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 40 ids in the raw snapshot: no newly listed and no delisted agents versus the previous run. (`antigravity-acp` and `kimchi` remain listed and deferred as binary-only; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: this is a lock version bump only; existing startup/session error paths already identify a failing agent by backend.
