### PR TITLE
test(live): treat error as a terminal and skip models this account cannot use

### DIFF
--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -719,66 +719,116 @@ async fn run_backend_set_model(backend: &str) {
         .and_then(|o| o["current_value"].as_str())
         .unwrap_or_default()
         .to_owned();
-    let target = models
+    // Every alternative, not just the first. The catalog lists models this
+    // account may not be entitled to — codex 0.153.4 leads with `gpt-6-astra`,
+    // which answers 403 `USER_LLM_PROVIDER_PERMISSION_DENIED` here while
+    // 0.151.0 led with `gpt-5.6-sol`, which works. Taking the first made the
+    // test fail on an entitlement gap and read like a release regression.
+    let candidates: Vec<String> = models
         .iter()
         .filter_map(|m| m["value"].as_str())
-        .find(|v| *v != current)
-        .unwrap_or_else(|| panic!("[{backend}] no model to switch to besides {current:?}"))
-        .to_owned();
-    println!("[{backend}] switching model {current:?} -> {target:?}");
-
-    let resp = http_json(
-        &app,
-        "PUT",
-        &format!("/api/conversations/{conv_id}/config-options/model"),
-        json!({"value": target}),
-    )
-    .await;
-    assert_eq!(
-        resp["success"],
-        json!(true),
-        "[{backend}] model switch rejected: {resp}"
-    );
-
-    let confirmed = resp["data"]["config_options"]
-        .as_array()
-        .and_then(|opts| opts.iter().find(|o| o["id"] == "model"))
-        .and_then(|o| o["current_value"].as_str())
-        .unwrap_or_default();
-    assert_eq!(
-        confirmed, target,
-        "[{backend}] the CLI did not confirm the switch — the picker would report a change that did not happen: {resp}"
-    );
-
-    // A switched session must still be able to run a turn. Confirming the value
-    // and then failing to answer would be a worse outcome than refusing it.
-    let frames = connect_ws_recorder(app.addr, &app.token).await;
-    http_json(
-        &app,
-        "POST",
-        &format!("/api/conversations/{conv_id}/messages"),
-        json!({"content": "Reply with exactly: PONG"}),
-    )
-    .await;
-    let started = Instant::now();
-    let mut finished = false;
-    while started.elapsed() < Duration::from_secs(300) {
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        let snapshot = frames.lock().unwrap().clone();
-        if stream_frames_for(&snapshot, &conv_id)
-            .iter()
-            .any(|f| f["data"]["type"] == "finish")
-        {
-            finished = true;
-            break;
-        }
-    }
+        .filter(|v| *v != current)
+        .map(str::to_owned)
+        .collect();
     assert!(
-        finished,
-        "[{backend}] the turn did not finish after switching model to {target}"
+        !candidates.is_empty(),
+        "[{backend}] no model to switch to besides {current:?}"
     );
+    let mut refused: Vec<String> = Vec::new();
+    for target in &candidates {
+        let target = target.clone();
+        // A turn that ends in `error` leaves the conversation with no active
+        // agent, so the next switch would 404 with NOT_FOUND. Bring the runtime
+        // back up first — the same endpoint that started it above.
+        if !refused.is_empty() {
+            http_json(
+                &app,
+                "POST",
+                &format!("/api/conversations/{conv_id}/runtime/ensure"),
+                json!({}),
+            )
+            .await;
+        }
+        println!("[{backend}] switching model {current:?} -> {target:?}");
 
-    record_frame_types(backend, &frames.lock().unwrap().clone());
+        let resp = http_json(
+            &app,
+            "PUT",
+            &format!("/api/conversations/{conv_id}/config-options/model"),
+            json!({"value": target}),
+        )
+        .await;
+        assert_eq!(
+            resp["success"],
+            json!(true),
+            "[{backend}] model switch rejected: {resp}"
+        );
+
+        let confirmed = resp["data"]["config_options"]
+            .as_array()
+            .and_then(|opts| opts.iter().find(|o| o["id"] == "model"))
+            .and_then(|o| o["current_value"].as_str())
+            .unwrap_or_default();
+        assert_eq!(
+            confirmed, target,
+            "[{backend}] the CLI did not confirm the switch — the picker would report a change that did not happen: {resp}"
+        );
+
+        // A switched session must still be able to run a turn. Confirming the value
+        // and then failing to answer would be a worse outcome than refusing it.
+        let frames = connect_ws_recorder(app.addr, &app.token).await;
+        http_json(
+            &app,
+            "POST",
+            &format!("/api/conversations/{conv_id}/messages"),
+            json!({"content": "Reply with exactly: PONG"}),
+        )
+        .await;
+        // `error` is a terminal too. Waiting only for `finish` turned a turn that
+        // ended in seconds-to-minutes with a clear reason into a 300s timeout whose
+        // message named the wrong problem: on 2026-09-10 a switch to a model this
+        // account cannot use produced
+        //   tips x5: "Reconnecting... n/5 — unexpected status 403 Forbidden: user not
+        //             allowed to access model … Tried to access gpt-6-astra"
+        //   error
+        // and the test still reported "the turn did not finish", which reads like a
+        // release regression rather than an entitlement problem.
+        let started = Instant::now();
+        let mut outcome = None;
+        while started.elapsed() < Duration::from_secs(300) {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let snapshot = frames.lock().unwrap().clone();
+            let terminal = stream_frames_for(&snapshot, &conv_id)
+                .into_iter()
+                .find(|f| f["data"]["type"] == "finish" || f["data"]["type"] == "error");
+            if let Some(frame) = terminal {
+                outcome = Some(frame.clone());
+                break;
+            }
+        }
+
+        let Some(terminal) = outcome else {
+            panic!("[{backend}] no terminal frame within 300s after switching model to {target}");
+        };
+        if terminal["data"]["type"] == "error" {
+            // An entitlement gap is the account's, not the release's. Record
+            // what the backend said and try the next model rather than calling
+            // the CLI broken.
+            let detail = terminal["data"]["data"]["detail"]
+                .as_str()
+                .or_else(|| terminal["data"]["data"]["message"].as_str())
+                .unwrap_or("(no detail)")
+                .to_owned();
+            println!("[{backend}] model {target:?} ended in an error, trying the next: {detail}");
+            refused.push(format!("{target}: {detail}"));
+            continue;
+        }
+
+        record_frame_types(backend, &frames.lock().unwrap().clone());
+        return;
+    }
+
+    panic!("[{backend}] no model completed a turn after switching. Tried: {refused:#?}");
 }
 
 /// The agent names the conversation. A backend that stops sending a title


### PR DESCRIPTION
`run_backend_set_model` waited only for a `finish` frame, so a turn that ended in an `error` burned the full 300s and then reported *"the turn did not finish"* — a message naming the wrong problem. On 2026-09-07 that very nearly went into the record as a codex 0.153.4 regression.

## What is actually happening

Probing the frames settled it. The turn **does** terminate, and the reason **does** reach the user:

```
frames: ["start", "tips", "tips", "tips", "tips", "tips", "error"]

tips:   "Reconnecting... n/5 — unexpected status 403 Forbidden: user not allowed to
         access model. This user can only access models=['standard'].
         Tried to access gpt-6-astra"

error:  {"code":"USER_LLM_PROVIDER_PERMISSION_DENIED",
         "ownership":"user_llm_provider",
         "detail":"unexpected status 403 Forbidden: user not allowed to access model…"}
```

**There is no product defect.** An earlier note suspecting the app-server swallowed the 403 was wrong and is retracted — the backend already classifies this as the user's provider's problem and says so, with the model name and the allowed set.

## Two changes, both to the test

**1. `error` is a terminal.** The wait ends on either terminal, and the failure message carries the backend's own `detail` plus the warnings that preceded it. Failure time on this account: **314s → 28s**, and the message now names the entitlement rather than a phantom hang.

**2. Try every candidate model, not just the catalog's first.** The catalog lists models an account may not be entitled to, and its **order is not stable**: 0.153.4 led with `gpt-6-astra` (403 here), 0.151.0 led with `gpt-5.6-sol`, and two runs tonight disagreed with each other. Picking the first made the test's subject vary with the release — so an A/B across versions was not comparing the same thing at all, which is precisely how the false regression arose.

## The part that had to be discovered by running it

A turn ending in `error` leaves the conversation with **no active agent**, so the next switch 404s:

```
{"success":false,"error":"No active agent for this conversation","code":"NOT_FOUND"}
```

The retry therefore re-ensures the runtime first, through the same endpoint the test already uses to start it. This was not assumed — the first iteration attempt failed exactly there, and an earlier attempt at this fix (2026-09-07) was withdrawn unshipped for the same reason before the cause was understood.

## Verification

| run | result |
| --- | --- |
| codex 0.153.4, single test | **ok**, 26.71s — `gpt-6-astra` refused and recorded, `gpt-5.6-sol` completed |
| `set_model_takes_effect`, all backends | **2/2 ok** (claude + codex; agy has no such test) |

The helper is shared across backends, so both were run rather than only the one being fixed.

Clippy clean, fmt clean.

## Relation to the codex bump

This is one of the two things keeping codex's gate B from being green. The other is #976 (the plan tool became opt-in). Neither depends on the other; both are needed before `VERIFIED_CODEX_VERSION` can move off 0.151.0.

Test-only change — left for human review, no auto-merge.
