### PR TITLE
fix(shell): strip verbatim UNC prefix for Windows terminal and use dunce canonicalize

### DIFF
--- a/crates/aionui-shell/Cargo.toml
+++ b/crates/aionui-shell/Cargo.toml
@@ -12,6 +12,7 @@ aionui-runtime.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
+dunce.workspace = true
 futures-util.workspace = true
 open.workspace = true
 which.workspace = true

--- a/crates/aionui-shell/src/shell.rs
+++ b/crates/aionui-shell/src/shell.rs
@@ -138,8 +138,7 @@ impl ShellService {
 
 fn validate_file_exists(file_path: &str) -> Result<std::path::PathBuf, ShellError> {
     let path = Path::new(file_path);
-    let canonical = path
-        .canonicalize()
+    let canonical = dunce::canonicalize(path)
         .map_err(|_| ShellError::FileNotFound(file_path.to_owned()))?;
     if !canonical.is_file() {
         return Err(ShellError::FileNotFound(file_path.to_owned()));
@@ -149,8 +148,7 @@ fn validate_file_exists(file_path: &str) -> Result<std::path::PathBuf, ShellErro
 
 fn validate_path_exists(file_path: &str) -> Result<std::path::PathBuf, ShellError> {
     let path = Path::new(file_path);
-    let canonical = path
-        .canonicalize()
+    let canonical = dunce::canonicalize(path)
         .map_err(|_| ShellError::FileNotFound(file_path.to_owned()))?;
     if !canonical.exists() {
         return Err(ShellError::FileNotFound(file_path.to_owned()));
@@ -160,8 +158,7 @@ fn validate_path_exists(file_path: &str) -> Result<std::path::PathBuf, ShellErro
 
 fn validate_directory_exists(dir_path: &str) -> Result<std::path::PathBuf, ShellError> {
     let path = Path::new(dir_path);
-    let canonical = path
-        .canonicalize()
+    let canonical = dunce::canonicalize(path)
         .map_err(|_| ShellError::DirectoryNotFound(dir_path.to_owned()))?;
     if !canonical.is_dir() {
         return Err(ShellError::DirectoryNotFound(dir_path.to_owned()));
@@ -170,7 +167,14 @@ fn validate_directory_exists(dir_path: &str) -> Result<std::path::PathBuf, Shell
 }
 
 fn build_windows_terminal_command(path: &str) -> String {
-    format!(r#"pushd "{path}""#)
+    let sanitized = if let Some(stripped) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{stripped}")
+    } else if let Some(stripped) = path.strip_prefix(r"\\?\") {
+        stripped.to_string()
+    } else {
+        path.to_string()
+    };
+    format!(r#"pushd "{sanitized}""#)
 }
 
 /// Build the `(program, args)` used to reveal `path` in the Linux file manager.
@@ -447,5 +451,14 @@ mod tests {
     fn build_windows_terminal_command_supports_unc_paths() {
         let command = build_windows_terminal_command(r#"\\server\share\My Project"#);
         assert_eq!(command, r#"pushd "\\server\share\My Project""#);
+    }
+
+    #[test]
+    fn build_windows_terminal_command_strips_verbatim_unc_prefix() {
+        let command = build_windows_terminal_command(r#"\\?\D:\My Project"#);
+        assert_eq!(command, r#"pushd "D:\My Project""#);
+
+        let unc_command = build_windows_terminal_command(r#"\\?\UNC\server\share\My Project"#);
+        assert_eq!(unc_command, r#"pushd "\\server\share\My Project""#);
     }
 }


### PR DESCRIPTION
### Summary
Fixes https://github.com/iOfficeAI/aionrs/issues/270

#### Problem
On Windows, when clicking 'Open Terminal' for a workspace located on non-system drives (e.g. `D:`), the system fails with:
```
指定的路径无效 (The filename, directory name, or volume label syntax is incorrect / path invalid)
```

#### Root Cause
1. `std::fs::canonicalize()` on Windows prepends the `\\?\\Extended-Length/Verbatim` prefix (e.g. `\\?\\D:\workspace`).
2. Windows `cmd.exe` does **not** support the `\\?\\Extended-Length` syntax. When executing `cmd /c start cmd /K pushd "\\?\\D:\..."`, `cmd.exe` rejects the `\\?\\...` prefix with `指定的路径无效`. (In contrast, `explorer.exe` resolves verbatim paths via Shell APIs, which is why 'Open Folder' worked fine).
3. The rest of the codebase (e.g., in `crates/aionui-app/src/services.rs`) specifically uses `dunce::canonicalize` for this exact reason to avoid the `\\?\\Extended-Length` prefix for Windows CLI compatibility.

#### Changes
1. Use `dunce::canonicalize` in `crates/aionui-shell/src/shell.rs` for `validate_file_exists`, `validate_path_exists`, and `validate_directory_exists`.
2. As defense in depth, sanitize `\\?\\UNC\\` and `\\?\\` prefixes in `build_windows_terminal_command`.
3. Add unit test coverage for `build_windows_terminal_command` verifying verbatim path stripping.