### PR TITLE
fix(agent): assign dedicated server port to opencode ACP spawns

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -205,6 +205,15 @@ pub(super) async fn build(
     .await;
     command_spec.args.extend(acp_delivery.plan.extra_args.iter().cloned());
 
+    // Give every opencode spawn its own explicit server port so a user-pinned
+    // `server.port` in the global opencode config cannot serialise concurrent
+    // conversations (see `pin_opencode_port` docs).
+    super::acp_launch_policy::pin_opencode_port(
+        &mut command_spec.args,
+        meta.backend.as_deref(),
+        &command_spec.command.to_string_lossy(),
+    );
+
     let session_snapshot = build_context.session_snapshot;
 
     // Load user-configured MCP servers from the DB so they reach

--- a/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
@@ -101,9 +101,150 @@ fn codex_sandbox_mode_for_requested_mode(mode: Option<&str>) -> &'static str {
     }
 }
 
+/// True when argv already pins the opencode ACP server port, either as
+/// `--port N` or `--port=N` (vendor-configured or user override). We must not
+/// append a second `--port`: last-one-wins would silently defeat the
+/// operator's explicit choice.
+pub(crate) fn command_spec_has_port(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--port" || arg.starts_with("--port="))
+}
+
+/// Ask the OS for a currently free TCP port on loopback. The listener is
+/// dropped immediately; the window between drop and opencode's own bind is
+/// tiny and a collision degrades to the pre-fix behaviour (single conversation
+/// on a shared machine), so we accept the race rather than hold the socket
+/// across the spawn.
+pub(crate) fn reserve_available_tcp_port() -> Option<u16> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).ok()?;
+    Some(listener.local_addr().ok()?.port())
+}
+
+/// True when this launch targets opencode: either the catalog backend says so
+/// (conversation runtime path) or the executable is literally `opencode` /
+/// `opencode.exe` (custom-agent probe path, where no backend label exists yet).
+/// The name fallback must stay narrow — other ACP CLIs (claude, codex, gemini,
+/// …) would die on an unknown `--port` flag.
+pub(crate) fn is_opencode_acp_launch(backend: Option<&str>, command: &str) -> bool {
+    if backend == Some("opencode") {
+        return true;
+    }
+    // `command` is either a bare program ("opencode"), a program path (which
+    // may itself contain spaces on Windows, e.g. "C:\Program Files\…"), or a
+    // program with embedded arguments ("npx -y pkg"-style). Test both the
+    // whole-string basename (covers paths with spaces) and the first-token
+    // basename (covers embedded args).
+    let basename = |candidate: &str| {
+        std::path::Path::new(candidate)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| candidate.to_owned())
+    };
+    let whole = basename(command);
+    if whole.eq_ignore_ascii_case("opencode") || whole.eq_ignore_ascii_case("opencode.exe") {
+        return true;
+    }
+    match command.split_whitespace().next() {
+        Some(first) => {
+            let head = basename(first);
+            head.eq_ignore_ascii_case("opencode") || head.eq_ignore_ascii_case("opencode.exe")
+        }
+        None => false,
+    }
+}
+
+/// Append a dedicated `--port <free>` to an opencode ACP launch argv unless
+/// one is already pinned.
+///
+/// Why: opencode's ACP adapter boots an internal HTTP server per process. Its
+/// `--port` CLI *default* (0 = random) loses to a user-pinned `server.port` in
+/// the global opencode config (`~/.config/opencode/opencode.jsonc`): yargs
+/// defaults do not override config values. A pinned port serialises spawns —
+/// the second concurrent conversation fails to bind, dies with `ServeError`
+/// before the ACP `initialize` handshake completes, and the UI surfaces
+/// `USER_AGENT_STARTUP_FAILED`. Passing an *explicit* `--port` does win over
+/// the config, so every spawn gets its own free port. Covers BOTH spawn paths:
+/// the conversation factory and the custom-agent validation probe.
+///
+/// Returns the assigned port when one was appended.
+pub(crate) fn pin_opencode_port(args: &mut Vec<String>, backend: Option<&str>, command: &str) -> Option<u16> {
+    if !is_opencode_acp_launch(backend, command) || command_spec_has_port(args) {
+        return None;
+    }
+    match reserve_available_tcp_port() {
+        Some(port) => {
+            args.extend(["--port".to_string(), port.to_string()]);
+            tracing::info!(
+                port,
+                "opencode: assigned dedicated ACP server port to avoid config-pinned collisions"
+            );
+            Some(port)
+        }
+        None => {
+            tracing::warn!(
+                "opencode: could not reserve a free port; falling back to opencode's default port selection"
+            );
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_spec_has_port_detects_both_spellings() {
+        assert!(command_spec_has_port(&["acp".into(), "--port".into(), "4711".into()]));
+        assert!(command_spec_has_port(&["acp".into(), "--port=4711".into()]));
+        assert!(!command_spec_has_port(&["acp".into()]));
+        // `--portmap` style lookalikes must not count as a pinned port.
+        assert!(!command_spec_has_port(&["acp".into(), "--portmap".into()]));
+    }
+
+    #[test]
+    fn reserve_available_tcp_port_returns_a_bindable_port() {
+        let port = reserve_available_tcp_port().expect("loopback ephemeral port must be available");
+        assert_ne!(port, 0);
+        // Port must still be bindable right after reservation (nothing else
+        // grabbed it), i.e. opencode's later bind would succeed.
+        let probe = std::net::TcpListener::bind(("127.0.0.1", port));
+        assert!(probe.is_ok(), "reserved port {port} was taken immediately");
+    }
+
+    #[test]
+    fn opencode_detection_accepts_backend_and_executable_name() {
+        assert!(is_opencode_acp_launch(Some("opencode"), "whatever"));
+        assert!(is_opencode_acp_launch(None, "opencode"));
+        assert!(is_opencode_acp_launch(None, "opencode.exe"));
+        assert!(is_opencode_acp_launch(
+            None,
+            r"C:\Program Files\x\resources\opencode-cli\opencode.exe"
+        ));
+        // Whole string is the path (may contain spaces) AND program-with-args form.
+        assert!(is_opencode_acp_launch(None, r"C:\tools\opencode.exe"));
+        assert!(is_opencode_acp_launch(None, "opencode acp"));
+        // Other ACP vendors must never receive an injected --port.
+        assert!(!is_opencode_acp_launch(Some("claude"), "claude"));
+        assert!(!is_opencode_acp_launch(None, "codex"));
+        assert!(!is_opencode_acp_launch(None, "gemini"));
+    }
+
+    #[test]
+    fn pin_opencode_port_appends_once_and_respects_explicit_choice() {
+        let mut args = vec!["acp".to_string()];
+        let port = pin_opencode_port(&mut args, Some("opencode"), "opencode").expect("port assigned");
+        assert_eq!(args, vec!["acp".to_string(), "--port".to_string(), port.to_string()]);
+        // Second call must be a no-op (already pinned now).
+        assert!(pin_opencode_port(&mut args, Some("opencode"), "opencode").is_none());
+        assert_eq!(args.len(), 3);
+        // User-pinned port is never overridden, and non-opencode is untouched.
+        let mut pinned = vec!["acp".to_string(), "--port".to_string(), "9999".to_string()];
+        assert!(pin_opencode_port(&mut pinned, Some("opencode"), "opencode").is_none());
+        assert_eq!(pinned.len(), 3);
+        let mut claude = vec!["acp".to_string()];
+        assert!(pin_opencode_port(&mut claude, Some("claude"), "claude").is_none());
+        assert_eq!(claude, vec!["acp".to_string()]);
+    }
 
     fn agent_metadata_with_backend(backend: Option<&str>) -> AgentMetadata {
         AgentMetadata {

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -1,7 +1,7 @@
 pub mod acp_assembler;
 
 mod acp;
-mod acp_launch_policy;
+pub(crate) mod acp_launch_policy;
 pub(crate) mod aionrs;
 mod antigravity;
 mod context;

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -131,6 +131,12 @@ async fn spawn_probe_process(
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect();
     final_args.extend(args.iter().cloned());
+    // Validation probes spawn the real CLI; give opencode probes their own
+    // explicit server port so a config-pinned `server.port` cannot kill the
+    // probe (and thus reject valid agent definitions) while another instance
+    // already holds the port. No backend label exists yet here (that is what
+    // the probe determines), so detection falls back to the executable name.
+    crate::factory::acp_launch_policy::pin_opencode_port(&mut final_args, None, &resolved.program.to_string_lossy());
 
     let mut final_env: Vec<EnvVar> = env
         .iter()


### PR DESCRIPTION
## Problem

With the global opencode config pinning `server.port` (e.g. `~/.config/opencode/opencode.jsonc`), the second concurrent OpenCode conversation fails to start with `USER_AGENT_STARTUP_FAILED`.

Each OpenCode conversation spawns its own `opencode acp`, which boots an internal HTTP server. The CLI default `--port 0` (random) loses to the config value, so the second process fails to bind and exits with `ServeError` before the ACP `initialize` handshake completes. An explicit `--port` does override the config.

## Change

`pin_opencode_port()` appends an OS-allocated free loopback `--port` to every opencode ACP launch that does not already carry an explicit one. Applied to both spawn paths: the conversation runtime factory and the custom-agent validation probe.

Detection matches the catalog backend (`opencode`) or the executable name (`opencode`/`opencode.exe`, including Windows paths with spaces); other ACP vendors are never touched. User/vendor-specified `--port` is respected.

## Testing

- 4 new unit tests: injection, idempotency, explicit `--port` respected, non-opencode binaries untouched, Windows paths with spaces.
- Manual e2e on a machine with `server.port` pinned: two concurrent OpenCode conversations now both reach a healthy runtime (previously the second died with `ServeError`); opencode custom-agent creation succeeds while the pinned port is occupied.
- `cargo test -p aionui-ai-agent --lib`: passes except pre-existing Windows-only `terminal::tests` failures (missing `echo`/shell binaries), identical on unmodified `main`.
