### PR TITLE
feat(opencode): single-process shared opencode serve for all conversations (opt-in)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "libc",
  "mime_guess",
  "regex",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -31,6 +31,7 @@ getrandom.workspace = true
 regex.workspace = true
 dashmap.workspace = true
 futures-util.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -103,6 +103,58 @@ pub(super) async fn build(
         .await;
     }
 
+    // Single-process shared opencode server (opt-in): with
+    // AIONUI_OPENCODE_SHARED_SERVER on, opencode conversations ATTACH (HTTP +
+    // durable SSE) to ONE shared `opencode serve` process owned by the
+    // process pool in `opencode_shared`, instead of spawning a dedicated
+    // `opencode acp` child per conversation. The static route table below
+    // stays untouched — its table tests pin opencode→AcpManager for the
+    // DEFAULT (toggle-off) world, which this gate does not change. Fork is
+    // refused (no server-side session-fork endpoint in the v2 API).
+    if crate::opencode_shared::shared_server_enabled() && config.backend.as_deref() == Some("opencode") {
+        if config.fork.is_some() {
+            return Err(AgentError::Conflict(
+                "opencode shared-server conversations cannot be forked yet".into(),
+            ));
+        }
+        let delivery = crate::factory::resolve_skill_delivery(
+            deps.as_ref(),
+            &ctx.user_id,
+            &ctx.conversation_id,
+            &config.skills,
+            &meta,
+        )
+        .await;
+        let instance = crate::session_agent::build_opencode_instance(crate::session_agent::SessionBuildInputs {
+            conversation_id: ctx.conversation_id.clone(),
+            user_id: ctx.user_id.clone(),
+            workspace: ctx.workspace.clone(),
+            config: &config,
+            metadata: &meta,
+            skill_delivery: delivery,
+            session_snapshot: build_context.session_snapshot.as_ref(),
+            backend_session_id: build_context.session_id.clone(),
+            mcp_server_repo: deps.mcp_server_repo.as_ref(),
+            // AIONUI_BASE_URL / _USER_ID / _HELPER_BIN ride to the server
+            // (stable per user); the pool strips AIONUI_CONVERSATION_ID at
+            // spawn — a shared process must not carry one conversation's
+            // identity (documented limitation of the shared mode).
+            runtime_env: &ctx.runtime_env,
+            broadcaster: deps.broadcaster.clone(),
+            catalog_writeback: Some((meta.id.clone(), deps.agent_registry.catalog_sender())),
+            acp_session_repo: Some(deps.acp_agent_service.repo()),
+            prompt_dump_dir: None,
+            permission_hook_body: None,
+        })
+        .await?;
+        tracing::info!(
+            conversation_id = %ctx.conversation_id,
+            backend = "opencode",
+            "opencode-shared: routing conversation through the shared opencode serve process"
+        );
+        return Ok(instance);
+    }
+
     // Session-model port: claude/codex ALWAYS run through the clean-slate direct-CLI
     // SessionBackend (SessionAgentTask), NOT the ACP manager. Every other ACP vendor
     // keeps the AcpAgentManager path below. There is no fallback: a claude/codex

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -20,6 +20,10 @@ pub mod manager;
 /// shape the `SessionBackend` stack carries in `SessionConfig.init.mcp_servers`.
 pub mod mcp_resolve;
 pub mod media;
+/// Single-process shared `opencode serve` backend (opt-in via
+/// `AIONUI_OPENCODE_SHARED_SERVER`): one HTTP/SSE server hosts every opencode
+/// conversation instead of one `opencode acp` child per conversation.
+pub mod opencode_shared;
 pub(crate) mod persistence;
 pub mod protocol;
 pub mod registry;

--- a/crates/aionui-ai-agent/src/opencode_shared/backend.rs
+++ b/crates/aionui-ai-agent/src/opencode_shared/backend.rs
@@ -1,0 +1,915 @@
+//! `SessionBackend` / `BackendConnection` implementation over the shared
+//! `opencode serve` HTTP/SSE server (see [`super::pool`]).
+//!
+//! One [`OpencodeSessionBackend`] == one opencode session (`ses_…`) hosted by
+//! the SHARED server; N conversations == N backends == ONE bun process.
+//!
+//! Pump architecture (all tasks per-session, all cheap localhost HTTP):
+//! * **SSE pump** — attaches `GET /api/session/{id}/event?after=<cursor>`,
+//!   parses `data:` JSON lines, feeds [`translate`], advances the durable
+//!   cursor; on transport loss reconnects from the cursor (server replays the
+//!   gap — verified across restarts).
+//! * **Pending poller** — `GET …/permission` + `GET …/question` and diffs the
+//!   local maps: asked events are NOT durable (captured: a turn blocked on
+//!   approval emits no asked event), so the poller is their only source, and
+//!   it makes pendings restart-resilient. Disappearance → auto-resolve.
+//! * **Active poller** — runs only while a turn is in flight; the session
+//!   leaving `GET /api/session/active` is the authoritative turn end
+//!   (captured: `/wait` answers 503 in 1.18.30 and `session.idle` is not in
+//!   the durable history), with a settle grace to drain trailing SSE frames.
+//! * **Death watcher** — pool liveness watch → `Detached` (crash avalanche:
+//!   every attached conversation detaches; the orchestrator's crash-respawn
+//!   re-opens against a fresh server from the persisted `ses_…` anchor).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use futures_util::StreamExt as _; // for stream::iter(..).chain(..) in events()
+use tokio::sync::{Mutex, broadcast};
+use tokio::task::JoinHandle;
+
+use aionui_session::{
+    Admission, BackendConnection, BackendError, BlockSet, Capabilities, CapabilityTier, Command, CommandReceipt,
+    CommandSet, ContentBlock, PendingPermissionView, PermissionDecision, PermissionKind, PromptAcceptedSource,
+    QuestionAnswer, SessionBackend, SessionConfig, SessionEnvelope, SessionEvent, SessionSpec, SignalSet,
+};
+
+use super::HttpError;
+use super::client::{OpencodeClient, PromptAdmit, sse_data_to_event};
+use super::pool::{ServerLease, global_pool};
+use super::translate::{self, TranslateState};
+
+/// Turn-end settle grace: let the SSE pump ingest the final frames (tool
+/// results / trailing text) racing the active-map flip.
+const TURN_SETTLE_GRACE: std::time::Duration = std::time::Duration::from_millis(600);
+const ACTIVE_POLL: std::time::Duration = std::time::Duration::from_millis(700);
+const PENDING_POLL: std::time::Duration = std::time::Duration::from_millis(1200);
+const SSE_RETRY_MAX: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// `dispatch` return for a command whose capability bit is off.
+fn not_supported(name: &'static str) -> BackendError {
+    BackendError::CommandNotSupported { command: name }
+}
+
+pub struct OpencodeConnection;
+
+struct SessionTasks {
+    sse: JoinHandle<()>,
+    pending: JoinHandle<()>,
+    active: JoinHandle<()>,
+    alive: JoinHandle<()>,
+    _lease: Arc<ServerLease>,
+}
+
+impl Default for OpencodeConnection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpencodeConnection {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl BackendConnection for OpencodeConnection {
+    async fn open_session(
+        &self,
+        spec: SessionSpec,
+        config: SessionConfig,
+    ) -> Result<Arc<dyn SessionBackend>, BackendError> {
+        let program = config
+            .cli_program
+            .clone()
+            .ok_or_else(|| BackendError::SetupRejected("opencode shared: no cli_program resolved".into()))?;
+        // SessionConfig.cwd is a plain String path (same one the ACP path spawns
+        // in); empty/None falls back to the process cwd.
+        let directory = match config.cwd.as_ref().filter(|c| !c.is_empty()) {
+            Some(c) => c.clone(),
+            None => std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| ".".to_string()),
+        };
+        if !std::path::Path::new(&directory).is_dir() {
+            return Err(BackendError::WorkspaceUnavailable(directory));
+        }
+
+        let spawn_env: Vec<(String, String)> = config
+            .spawn_env
+            .iter()
+            .map(|e| (e.name.clone(), e.value.clone()))
+            .collect();
+        let acquired = global_pool()
+            .acquire(Path::new(&program), &spawn_env)
+            .await
+            .map_err(BackendError::Transport)?;
+        let client = OpencodeClient::new(&acquired.lease.info);
+
+        // Two-id model: opencode's `ses_…` is the BACKEND id; the orchestrator's
+        // envelope always carries the LOGICAL conversation id.
+        let logical_id = match &spec {
+            SessionSpec::Fresh { session_id } | SessionSpec::Resume { session_id, .. } => session_id.clone(),
+            // Fork is refused at the factory (see build_opencode_instance);
+            // defensive: treat as Fresh-on-parent-id impossible here, so fail
+            // loudly rather than silently opening the wrong context.
+            SessionSpec::Fork { .. } => {
+                return Err(BackendError::SetupRejected(
+                    "opencode shared backend does not support fork (product decision, mirrors antigravity)".into(),
+                ));
+            }
+        };
+
+        // Resolve the opencode session id: resume-if-alive, else create fresh.
+        // A dead anchor falls back to a NEW session — history continuity is the
+        // orchestrator's rehydrate's job (DB), and the fresh id is reported via
+        // BackendBound so the anchor repo self-heals.
+        let requested = match &spec {
+            SessionSpec::Resume {
+                backend_session_id: Some(id),
+                ..
+            } => Some(id.clone()),
+            _ => None,
+        };
+        let (backend_id, _created_fresh) = match &requested {
+            Some(id) if client.get_session(id).await.is_ok() => (id.clone(), false),
+            _ => {
+                let (id, _project) = client.create_session(&directory).await.map_err(transport_err)?;
+                (id, true)
+            }
+        };
+
+        // Apply the selected model (POST …/model switches the session model
+        // mid-life — live-verified; create body cannot carry it, so both fresh
+        // and resumed sessions converge here). Failures are non-fatal: a
+        // wrong/stale id just keeps the server default, matching how the ACP
+        // path treats an unresolvable --model.
+        if let Some(model) = config.model.as_deref().filter(|m| !m.trim().is_empty())
+            && let Err(e) = client.set_model(&backend_id, model).await
+        {
+            tracing::warn!(backend_session_id = %backend_id, model, error = %e,
+                "opencode shared: model switch rejected (server default stays in effect)");
+        }
+
+        let (tx, _rx0) = broadcast::channel::<SessionEnvelope>(2048);
+        let epoch = Arc::new(AtomicU64::new(0));
+        let turn_in_flight = Arc::new(AtomicBool::new(false));
+        let cancel_requested = Arc::new(AtomicBool::new(false));
+        let translate = Arc::new(Mutex::new(TranslateState::default()));
+        let cursor = Arc::new(AtomicU64::new(0));
+        // History tail first: seeds the cursor at the durable tip so the live
+        // subscription never replays old turns (they live in the DB via
+        // rehydrate), and marks restart-surviving pendings.
+        let tip = {
+            let hist = client.history_tail(&backend_id).await;
+            hist.iter().rev().find_map(|e| e.seq).unwrap_or(0)
+        };
+        cursor.store(tip, Ordering::SeqCst);
+
+        let st = Arc::new(SessionState {
+            logical_id: logical_id.clone(),
+            backend_id: backend_id.clone(),
+            client: client.clone(),
+            tx,
+            epoch: epoch.clone(),
+            turn_in_flight: turn_in_flight.clone(),
+            cancel_requested: cancel_requested.clone(),
+            translate: translate.clone(),
+            cursor: cursor.clone(),
+            pending_perms: Arc::new(Mutex::new(HashMap::new())),
+            pending_asks: Arc::new(Mutex::new(HashMap::new())),
+            // First-prompt context injection (preset + skill index), consumed
+            // by the first Send — the SessionInit channel the shared spawn has
+            // no process-level surface for.
+            pending_context: Arc::new(Mutex::new(config.init.preset_context.clone())),
+        });
+
+        let sse = spawn_sse_pump(st.clone());
+        let pending = spawn_pending_poller(st.clone());
+        let alive = spawn_death_watcher(st.clone(), acquired.alive.clone());
+        // Turn closer: flips TurnResult when the active map empties. Lives for
+        // the session's lifetime but only WORKS while a turn is in flight.
+        let active = spawn_active_poller(st.clone());
+
+        st.emit(SessionEvent::BackendBound {
+            backend_session_id: Some(backend_id.clone()),
+        });
+
+        let backend = Arc::new(OpencodeSessionBackend {
+            state: st,
+            // Teardown is Drop-driven (same contract as the codex backend's
+            // Drop-reap): abort pumps, release the pool lease. close_session
+            // is therefore a no-op — the orchestrator releases its Arc and the
+            // Drop fires; a lingering orchestrator clone keeps the pumps alive
+            // until the task truly unwinds, which is exactly desired.
+            tasks: std::sync::Mutex::new(Some(SessionTasks {
+                sse,
+                pending,
+                active,
+                alive,
+                _lease: acquired.lease,
+            })),
+        });
+        Ok(backend)
+    }
+
+    async fn close_session(&self, session_id: &str) -> Result<(), BackendError> {
+        // Drop-driven teardown (see above). Teardown is idempotent either way;
+        // nothing to retract here.
+        let _ = session_id;
+        Ok(())
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        opencode_capabilities()
+    }
+}
+
+fn transport_err(e: HttpError) -> BackendError {
+    BackendError::Transport(e.to_string())
+}
+
+/// Shared per-session handle state used by every pump.
+struct SessionState {
+    logical_id: String,
+    backend_id: String,
+    client: OpencodeClient,
+    tx: broadcast::Sender<SessionEnvelope>,
+    epoch: Arc<AtomicU64>,
+    turn_in_flight: Arc<AtomicBool>,
+    cancel_requested: Arc<AtomicBool>,
+    translate: Arc<Mutex<TranslateState>>,
+    cursor: Arc<AtomicU64>,
+    /// request_id → card metadata (for pending_permission_requests() recovery
+    /// and auto-resolve on disappearance).
+    pending_perms: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+    pending_asks: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+    pending_context: Arc<Mutex<Option<String>>>,
+}
+
+impl SessionState {
+    fn emit(&self, event: SessionEvent) {
+        let env = SessionEnvelope {
+            session_id: self.logical_id.clone(),
+            turn_gen: self.epoch.load(Ordering::SeqCst),
+            event,
+        };
+        // Send fails only when nobody listens (closed session): drop silently,
+        // same tolerance as the codex adapter's emit helper.
+        let _ = self.tx.send(env);
+    }
+}
+
+/// SSE pump with cursor-resumable reconnect.
+fn spawn_sse_pump(st: Arc<SessionState>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut backoff = std::time::Duration::from_millis(250);
+        loop {
+            let after = st.cursor.load(Ordering::SeqCst);
+            match st.client.event_stream(&st.backend_id, Some(after)).await {
+                Ok(mut resp) => {
+                    backoff = std::time::Duration::from_millis(250);
+                    // chunk() (not bytes_stream()) so the workspace's
+                    // feature-light reqwest suffices — no extra feature gate.
+                    let mut buf: Vec<u8> = Vec::new();
+                    let mut gone = false;
+                    // chunk() yields Result<Option<Bytes>> — None is a clean
+                    // end-of-stream, Err is a broken connection.
+                    loop {
+                        match resp.chunk().await {
+                            Ok(Some(bytes)) => {
+                                buf.extend_from_slice(&bytes);
+                                // SSE frames end at a blank line; process by
+                                // DATA lines (opencode never uses `event:`).
+                                while let Some(pos) = find_line_end(&buf) {
+                                    let line: Vec<u8> = buf.drain(..=pos).collect();
+                                    let line = String::from_utf8_lossy(&line);
+                                    let line = line.trim_end_matches(['\r', '\n']);
+                                    let Some(payload) = line.strip_prefix("data:") else {
+                                        continue;
+                                    };
+                                    let payload = payload.trim();
+                                    if payload.is_empty() {
+                                        continue;
+                                    }
+                                    let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) else {
+                                        continue;
+                                    };
+                                    let Some(ev) = sse_data_to_event(v) else { continue };
+                                    if let Some(seq) = ev.seq {
+                                        st.cursor.fetch_max(seq + 1, Ordering::SeqCst);
+                                    }
+                                    handle_stream_event(&st, &ev).await;
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(e) => {
+                                tracing::debug!(backend = %st.backend_id, error = %e,
+                                    "opencode shared sse stream broke; reconnecting");
+                                gone = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !gone {
+                        // Clean end-of-stream (server closed the subscription):
+                        // reconnect too.
+                        tracing::debug!(backend = %st.backend_id, "opencode shared sse ended; reconnecting");
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(backend = %st.backend_id, error = %e,
+                        "opencode shared sse connect failed; retrying");
+                }
+            }
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(SSE_RETRY_MAX);
+        }
+    })
+}
+
+fn find_line_end(buf: &[u8]) -> Option<usize> {
+    buf.iter().position(|b| *b == b'\n')
+}
+
+/// SSE-side handling: translate + a few lifecycle cases the translate layer
+/// cannot decide alone (turn-end promotion of error/idle, asked-card dedupe).
+async fn handle_stream_event(st: &SessionState, ev: &super::client::StreamEvent) {
+    match ev.event_type.as_str() {
+        // Durable prompt echo frames are owned by dispatch's receipts.
+        "session.next.prompt.admitted" | "session.next.prompted" => {}
+        "session.idle" => {
+            finalize_turn(st, /*from_error*/ false).await;
+        }
+        "session.error" => {
+            // Promote to a failed turn-end when one is in flight (the durable
+            // `tool.failed`/`step.ended` trail already told the story; the
+            // Notice below rides too so a non-turn error still surfaces).
+            finalize_turn(st, /*from_error*/ true).await;
+            let mut tr = st.translate.lock().await;
+            for e in translate::translate(ev, &mut tr) {
+                st.emit(e);
+            }
+        }
+        "permission.v2.asked" => {
+            upsert_permission(st, &ev.data).await;
+        }
+        "question.v2.asked" => {
+            upsert_question(st, &ev.data).await;
+        }
+        _ => {
+            let mut tr = st.translate.lock().await;
+            for e in translate::translate(ev, &mut tr) {
+                st.emit(e);
+            }
+        }
+    }
+}
+
+async fn upsert_permission(st: &SessionState, d: &serde_json::Value) {
+    let id = d
+        .get("requestID")
+        .and_then(|v| v.as_str())
+        .or_else(|| d.get("id").and_then(|v| v.as_str()))
+        .unwrap_or_default()
+        .to_string();
+    if id.is_empty() {
+        return;
+    }
+    let is_new = !st.pending_perms.lock().await.contains_key(&id);
+    if !is_new {
+        return;
+    }
+    let tool_name = d.get("action").and_then(|v| v.as_str()).map(str::to_string);
+    let input = d.get("resources").cloned().or_else(|| d.get("metadata").cloned());
+    st.pending_perms.lock().await.insert(id.clone(), d.clone());
+    st.emit(SessionEvent::Permission {
+        request_id: id.clone(),
+        kind: PermissionKind::Tool,
+        metadata: None,
+        tool_name,
+        input,
+    });
+}
+
+async fn upsert_question(st: &SessionState, d: &serde_json::Value) {
+    let id = d
+        .get("requestID")
+        .and_then(|v| v.as_str())
+        .or_else(|| d.get("id").and_then(|v| v.as_str()))
+        .unwrap_or_default()
+        .to_string();
+    if id.is_empty() {
+        return;
+    }
+    {
+        let mut map = st.pending_asks.lock().await;
+        if map.contains_key(&id) {
+            return;
+        }
+        map.insert(id.clone(), d.clone());
+    }
+    // The UI's Ask card consumes {questions:[{question,header,options[…]}]};
+    // opencode's request carries exactly that array (captured shape) — pass it
+    // through under the same key (plus the tool info for display context).
+    let payload = serde_json::json!({
+        "questions": d.get("questions").cloned().unwrap_or_else(|| serde_json::json!([])),
+    });
+    st.emit(SessionEvent::Ask {
+        request_id: id,
+        questions: payload,
+    });
+}
+
+/// Pending permission/question poller: authoritative ask/retract diff.
+fn spawn_pending_poller(st: Arc<SessionState>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(PENDING_POLL).await;
+            poll_pending_once(&st).await;
+        }
+    })
+}
+
+async fn poll_pending_once(st: &SessionState) {
+    // ── permissions ──
+    let live: HashMap<String, serde_json::Value> = st
+        .client
+        .pending_permissions(&st.backend_id)
+        .await
+        .into_iter()
+        .filter_map(|v| {
+            let id = v
+                .get("id")
+                .or_else(|| v.get("requestID"))
+                .and_then(|i| i.as_str())
+                .map(str::to_string)?;
+            Some((id, v))
+        })
+        .collect();
+    let mut map = st.pending_perms.lock().await;
+    let gone: Vec<String> = map.keys().filter(|k| !live.contains_key(*k)).cloned().collect();
+    for id in &gone {
+        map.remove(id);
+    }
+    let fresh: Vec<(String, serde_json::Value)> = live
+        .iter()
+        .filter(|(id, _)| !map.contains_key(*id))
+        .map(|(id, d)| (id.clone(), d.clone()))
+        .collect();
+    drop(map);
+    for id in gone {
+        st.emit(SessionEvent::PermissionResolved {
+            request_id: id,
+            kind: PermissionKind::Tool,
+        });
+    }
+    for (_id, d) in fresh {
+        upsert_permission(st, &d).await;
+    }
+
+    // ── questions ──
+    let live_q: HashMap<String, serde_json::Value> = st
+        .client
+        .pending_questions(&st.backend_id)
+        .await
+        .into_iter()
+        .filter_map(|v| {
+            let id = v
+                .get("id")
+                .or_else(|| v.get("requestID"))
+                .and_then(|i| i.as_str())
+                .map(str::to_string)?;
+            Some((id, v))
+        })
+        .collect();
+    let mut map = st.pending_asks.lock().await;
+    let gone_q: Vec<String> = map.keys().filter(|k| !live_q.contains_key(*k)).cloned().collect();
+    for id in &gone_q {
+        map.remove(id);
+    }
+    let fresh_q: Vec<(String, serde_json::Value)> = live_q
+        .iter()
+        .filter(|(id, _)| !map.contains_key(*id))
+        .map(|(id, d)| (id.clone(), d.clone()))
+        .collect();
+    drop(map);
+    for id in gone_q {
+        st.emit(SessionEvent::AskResolved { request_id: id });
+    }
+    for (_id, d) in fresh_q {
+        upsert_question(st, &d).await;
+    }
+}
+
+/// Active-map turn closer: when the in-flight session leaves
+/// `GET /api/session/active`, settle + finalize.
+fn spawn_active_poller(st: Arc<SessionState>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(ACTIVE_POLL).await;
+            if !st.turn_in_flight.load(Ordering::SeqCst) {
+                continue;
+            }
+            match st.client.session_active(&st.backend_id).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    tokio::time::sleep(TURN_SETTLE_GRACE).await;
+                    // Re-check: a steer may have re-activated the session
+                    // inside the grace window.
+                    if matches!(st.client.session_active(&st.backend_id).await, Ok(true)) {
+                        continue;
+                    }
+                    finalize_turn(&st, false).await;
+                }
+                Err(_) => {
+                    // Transport blip during the turn: the crash path (pool
+                    // watchdog → Detached) or a later successful poll will
+                    // settle this; do not finalize on unknown state.
+                }
+            }
+        }
+    })
+}
+
+/// Close the turn exactly once per dispatch (guarded by the
+/// turn_in_flight flip).
+async fn finalize_turn(st: &SessionState, from_error: bool) {
+    if !st.turn_in_flight.swap(false, Ordering::SeqCst) {
+        return; // already finalized (idle beat the poller, or Cancel settled)
+    }
+    let cancelled = st.cancel_requested.swap(false, Ordering::SeqCst);
+    // Drain the translate accumulators under the lock AFTER trailing frames
+    // were handled — the finalizer runs on pump-adjacent tasks that hold no
+    // lock, and the grace above ordered them.
+    let usage = {
+        let tr = st.translate.lock().await;
+        tr.turn_usage_event()
+    };
+    st.emit(usage);
+    // Stamp the epoch onto the built terminal event.
+    let mut terminal = translate::turn_result_event(from_error, cancelled);
+    if let SessionEvent::TurnResult { epoch, .. } = &mut terminal {
+        *epoch = st.epoch.load(Ordering::SeqCst);
+    }
+    st.emit(terminal);
+}
+
+fn spawn_death_watcher(st: Arc<SessionState>, mut alive: tokio::sync::watch::Receiver<bool>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            if alive.changed().await.is_err() {
+                return; // sender gone (pool entry reaped normally)
+            }
+            if !(*alive.borrow()) {
+                st.emit(SessionEvent::Detached {
+                    exit: None,
+                    redacted_summary: Some("shared opencode server stopped".into()),
+                });
+                return;
+            }
+        }
+    })
+}
+
+/// The per-session backend actor.
+pub struct OpencodeSessionBackend {
+    state: Arc<SessionState>,
+    /// Real pump tasks + pool lease; aborted on Drop (same teardown contract
+    /// as the codex backend's Drop-reap).
+    tasks: std::sync::Mutex<Option<SessionTasks>>,
+}
+
+impl Drop for OpencodeSessionBackend {
+    fn drop(&mut self) {
+        if let Some(t) = self.tasks.lock().ok().and_then(|mut o| o.take()) {
+            t.sse.abort();
+            t.pending.abort();
+            t.active.abort();
+            t.alive.abort();
+            // _lease drops with the tasks → pool refcount −1 (server stops at
+            // last lease; foreign servers are never killed).
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionBackend for OpencodeSessionBackend {
+    async fn dispatch(&self, command: Command) -> Result<CommandReceipt, BackendError> {
+        let st = &self.state;
+        match command {
+            Command::Send { content, metadata } => {
+                if st.turn_in_flight.load(Ordering::SeqCst) {
+                    // Orchestrator normally guards this; steer through Send is
+                    // explicitly a Command below.
+                    return Err(BackendError::Transport(
+                        "a turn is already in flight (use Steer)".into(),
+                    ));
+                }
+                let mut text = String::new();
+                for b in &content {
+                    // Layer-2 rule (§C6): reject un-advertised blocks with the
+                    // stable content_block:<kind> name, never a silent drop.
+                    if let ContentBlock::Text(t) = b {
+                        if !text.is_empty() {
+                            text.push('\n');
+                        }
+                        text.push_str(t);
+                    } else {
+                        return Err(BackendError::CommandNotSupported {
+                            command: aionui_session::block_kind_name(b),
+                        });
+                    }
+                }
+                if text.trim().is_empty() {
+                    return Err(BackendError::Transport("empty prompt".into()));
+                }
+                // Consume the one-shot injected context (preset rules + skill
+                // index composed by the factory) ahead of the first prompt.
+                let injected = st.pending_context.lock().await.take();
+                let final_text = match injected {
+                    Some(ctx) if !ctx.trim().is_empty() => format!("{}\n\n{}", ctx.trim_end(), text),
+                    _ => text.clone(),
+                };
+                let admit: PromptAdmit = st
+                    .client
+                    .prompt(&st.backend_id, &final_text)
+                    .await
+                    .map_err(transport_err)?;
+                let next_gen = st.epoch.fetch_add(1, Ordering::SeqCst) + 1;
+                st.turn_in_flight.store(true, Ordering::SeqCst);
+                st.cancel_requested.store(false, Ordering::SeqCst);
+                st.translate.lock().await.begin_turn();
+                st.emit(SessionEvent::TurnStarted { epoch: next_gen });
+                if let Some(cid) = metadata.client_msg_id {
+                    st.emit(SessionEvent::PromptAccepted { client_msg_id: cid });
+                }
+                tracing::debug!(backend = %st.backend_id, admitted_seq = ?admit.admitted_seq, id = %admit.id,
+                    "opencode shared: prompt admitted");
+                Ok(CommandReceipt {
+                    accepted: true,
+                    admission: Admission::Started,
+                    turn_gen: next_gen,
+                })
+            }
+            Command::Steer { content, client_msg_id } => {
+                // opencode's delivery:"steer" admits durably and the scheduler
+                // folds it into the running loop — same semantics, no gate.
+                let mut text = String::new();
+                for b in &content {
+                    if let ContentBlock::Text(t) = b {
+                        if !text.is_empty() {
+                            text.push('\n');
+                        }
+                        text.push_str(t);
+                    }
+                }
+                if text.trim().is_empty() {
+                    return Err(BackendError::Transport("empty steer".into()));
+                }
+                st.client.prompt(&st.backend_id, &text).await.map_err(transport_err)?;
+                if let Some(cid) = client_msg_id {
+                    st.emit(SessionEvent::PromptAccepted { client_msg_id: cid });
+                }
+                Ok(CommandReceipt {
+                    accepted: true,
+                    admission: Admission::NoTurn,
+                    turn_gen: st.epoch.load(Ordering::SeqCst),
+                })
+            }
+            Command::Cancel { target } => {
+                use aionui_session::CancelTarget as T;
+                match target {
+                    T::Tool(_) => Err(not_supported("cancel_tool")),
+                    T::Turn | T::Session => {
+                        st.client.interrupt(&st.backend_id).await.map_err(transport_err)?;
+                        st.cancel_requested.store(true, Ordering::SeqCst);
+                        // Finalize proactively: the active map will settle the
+                        // same way; whoever flips first owns the single
+                        // TurnResult{Cancelled}.
+                        finalize_turn(&self.state, false).await;
+                        Ok(CommandReceipt {
+                            accepted: true,
+                            admission: Admission::NoTurn,
+                            turn_gen: st.epoch.load(Ordering::SeqCst),
+                        })
+                    }
+                }
+            }
+            Command::AnswerPermission {
+                request_id,
+                decision,
+                // opencode permission replies are the single reply string;
+                // multi-choice selections and question-form answers belong to
+                // the Ask channel, not this one.
+                selected: _,
+                answers: _,
+            } => {
+                let reply = match decision {
+                    PermissionDecision::Approved => "once",
+                    PermissionDecision::AllowAlways => "always",
+                    PermissionDecision::Denied => "reject",
+                };
+                st.client
+                    .reply_permission(&st.backend_id, &request_id, reply)
+                    .await
+                    .map_err(transport_err)?;
+                let mut m = st.pending_perms.lock().await;
+                m.remove(&request_id);
+                drop(m);
+                st.emit(SessionEvent::PermissionResolved {
+                    request_id,
+                    kind: PermissionKind::Tool,
+                });
+                Ok(CommandReceipt {
+                    accepted: true,
+                    admission: Admission::NoTurn,
+                    turn_gen: st.epoch.load(Ordering::SeqCst),
+                })
+            }
+            Command::AnswerAsk { request_id, answers } => {
+                match answers {
+                    Some(qas) => {
+                        // QuestionV2.Answer = one string-array per question, in
+                        // question order (flat arrays 400 — captured). AionUi
+                        // hands us QuestionAnswer{question, labels}; the labels
+                        // are the answer, order preserved.
+                        let mapped: Vec<Vec<String>> = qas.iter().map(|q: &QuestionAnswer| q.labels.clone()).collect();
+                        st.client
+                            .reply_question(&st.backend_id, &request_id, mapped)
+                            .await
+                            .map_err(transport_err)?;
+                    }
+                    None => {
+                        st.client
+                            .reject_question(&st.backend_id, &request_id)
+                            .await
+                            .map_err(transport_err)?;
+                    }
+                }
+                let mut m = st.pending_asks.lock().await;
+                m.remove(&request_id);
+                drop(m);
+                st.emit(SessionEvent::AskResolved { request_id });
+                Ok(CommandReceipt {
+                    accepted: true,
+                    admission: Admission::NoTurn,
+                    turn_gen: st.epoch.load(Ordering::SeqCst),
+                })
+            }
+            Command::SetModel { model } => {
+                st.client
+                    .set_model(&st.backend_id, &model)
+                    .await
+                    .map_err(transport_err)?;
+                st.emit(SessionEvent::ConfigChanged {
+                    mode: None,
+                    model: Some(model),
+                });
+                Ok(CommandReceipt {
+                    accepted: true,
+                    admission: Admission::NoTurn,
+                    turn_gen: st.epoch.load(Ordering::SeqCst),
+                })
+            }
+            Command::Acknowledge { .. } => Ok(CommandReceipt {
+                accepted: true,
+                admission: Admission::NoTurn,
+                turn_gen: st.epoch.load(Ordering::SeqCst),
+            }),
+            Command::SetMode { .. } => Err(not_supported("set_mode")),
+            Command::AnswerAuth { .. } => Err(not_supported("answer_auth")),
+            Command::Rewind { .. } => Err(not_supported("rewind")),
+            Command::ListCheckpoints => Err(not_supported("list_checkpoints")),
+            Command::SetConfigOption { .. } => Err(not_supported("set_config_option")),
+            Command::QuerySessionInfo { .. } => Err(not_supported("query_session_info")),
+        }
+    }
+
+    fn events(&self) -> futures_util::stream::BoxStream<'static, SessionEnvelope> {
+        // Codex precedent (codex_conn::events): the open-time BackendBound is
+        // broadcast before the orchestrator subscribes and would be lost — the
+        // conversation would never persist its `ses_` resume anchor (and a
+        // crash-time redacted_summary would be lost). Replay the binding,
+        // immutable since open, to EVERY new subscriber; the same-value
+        // re-emit is idempotent downstream.
+        let st = &self.state;
+        let preface = vec![SessionEnvelope {
+            session_id: st.logical_id.clone(),
+            turn_gen: st.epoch.load(Ordering::SeqCst),
+            event: SessionEvent::BackendBound {
+                backend_session_id: Some(st.backend_id.clone()),
+            },
+        }];
+        let rx = st.tx.subscribe();
+        let live = futures_util::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(env) => return Some((env, rx)),
+                    // Lagging drops events but never stalls the reader forever
+                    // (the durable SSE cursor catches up on reconnect): keep
+                    // the stream alive like codex does.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Box::pin(futures_util::stream::iter(preface).chain(live))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        opencode_capabilities()
+    }
+
+    fn pending_permission_requests(&self) -> Vec<PendingPermissionView> {
+        // REST recovery for a reloaded waiting_confirmation conversation — the
+        // registry this reads survives server RESTARTS (the poller re-lists
+        // pendings on each pass), which the transient SSE cards cannot do.
+        self.state
+            .pending_perms
+            .blocking_lock()
+            .iter()
+            .map(|(id, d)| PendingPermissionView {
+                request_id: id.clone(),
+                tool_name: d.get("action").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+                // opencode permissions are plain tool approvals (questions
+                // ride the Ask channel), so no question-card rebuild.
+                questions: None,
+            })
+            .collect()
+    }
+
+    async fn terminate(&self) {
+        // A per-session terminate cannot kill the SHARED server — cancel the
+        // running turn instead (opencode has no heavier per-session kill
+        // surface in this build; lease release through Drop is the real
+        // teardown, and the pool only stops the server at last lease).
+        let st = &self.state;
+        if st.turn_in_flight.load(Ordering::SeqCst) {
+            let _ = st.client.interrupt(&st.backend_id).await;
+            st.cancel_requested.store(true, Ordering::SeqCst);
+            finalize_turn(st, false).await;
+        }
+    }
+}
+
+/// Capability advertisement drives UI affordances; every `false` here is
+/// matched by a `CommandNotSupported` in dispatch (cap-behavior invariant,
+/// same discipline as codex's comment block).
+pub fn opencode_capabilities() -> Capabilities {
+    Capabilities {
+        // Native structured event stream (same grade as codex's JSON-RPC
+        // notifications) — no regex/text parsing anywhere.
+        tier: CapabilityTier::Hook,
+        emits: SignalSet {
+            // tool.progress frames ride as Heartbeat; the durable SSE stream
+            // carries full tool lifecycle and an authoritative TurnResult
+            // (active-map settle), so the orchestrator suppresses its
+            // generated fallbacks.
+            heartbeat: true,
+            tool_lifecycle: true,
+            terminal_result: true,
+        },
+        supported_commands: CommandSet {
+            // POST /prompt with delivery:"steer" is the real mid-turn wire.
+            steer: true,
+            // opencode has no per-tool abort — only session interrupt.
+            cancel_tool: false,
+            answer_permission: true,
+            // No ACP auth handshake; opencode sign-in is out of band.
+            answer_auth: false,
+            // Permission cards are answered via REST and self-resolve; the
+            // node_ack path is accepted as a no-op (no node is ever emitted).
+            acknowledge: true,
+            // No mode selector on the v2 API (no plan/agent toggle endpoint).
+            set_mode: false,
+            // POST /api/session/{id}/model → 204 (live-verified).
+            set_model: true,
+            rewind: false,
+            list_checkpoints: false,
+            query_session_info: false,
+        },
+        // Text-only: the v2 prompt body is plain text (verified — images and
+        // resources have no wire here; dispatch answers with the stable
+        // content_block:<kind> refusal instead of silently dropping).
+        prompt_blocks: BlockSet {
+            text: true,
+            image: false,
+            audio: false,
+            resource: false,
+            at_mention: false,
+        },
+        // opencode's POST /prompt 200 {admittedSeq} is exactly the Native ack
+        // the enum docs cite.
+        prompt_accepted: PromptAcceptedSource::Native,
+        // Mid-turn user input goes through Command::Steer, which genuinely
+        // reaches the running turn over HTTP; the orchestrator owns the
+        // idle-time queue (Send mid-turn is refused), so no proactive-input.
+        accepts_proactive_input: false,
+        supports_midturn_delivery: true,
+        ..Default::default()
+    }
+}

--- a/crates/aionui-ai-agent/src/opencode_shared/client.rs
+++ b/crates/aionui-ai-agent/src/opencode_shared/client.rs
@@ -1,0 +1,415 @@
+//! Thin typed wrapper over the `opencode serve` V2 HTTP API (verified against
+//! opencode 1.18.30 `/doc`): session create/get, durable-input prompt,
+//! interrupt, model/agent switch, pending permission/question lists + replies,
+//! history, and the replayable session SSE stream.
+//!
+//! Everything speaks the `/api/*` namespace — the legacy `/session*` routes
+//! are only kept alive by opencode for SDK compat and their `GET /event` bus
+//! is a no-op in this build (confirmed live: zero events even attached during
+//! a turn), so the shared backend must not depend on them.
+
+use std::sync::OnceLock;
+
+use serde_json::{Value, json};
+
+use super::pool::{ServerInfo, auth_header, shared_client};
+
+/// Dedicated client for the long-lived SSE GET: unlike the pooled
+/// `shared_client()` (30s overall timeout), an idle event stream must never be
+/// timed out. reqwest applies no timeout unless one is set.
+static SSE_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+#[derive(Clone)]
+pub struct OpencodeClient {
+    http: reqwest::Client,
+    base_url: String,
+    auth: Option<String>,
+}
+
+/// One parsed SSE record. opencode frames every event as a single
+/// `data: {json}` line (no `event:` field — confirmed live capture); the
+/// durable envelope carries `{id, type, durable:{seq}, data}`.
+#[derive(Debug, Clone)]
+pub struct StreamEvent {
+    pub seq: Option<u64>,
+    pub event_type: String,
+    pub data: Value,
+}
+
+pub fn sse_data_to_event(v: Value) -> Option<StreamEvent> {
+    let event_type = v.get("type")?.as_str()?.to_string();
+    let seq = v.get("durable").and_then(|d| d.get("seq")).and_then(|s| s.as_u64());
+    let data = v.get("data").cloned().unwrap_or(Value::Null);
+    Some(StreamEvent { seq, event_type, data })
+}
+
+impl OpencodeClient {
+    pub fn new(info: &ServerInfo) -> Self {
+        Self {
+            http: shared_client(),
+            base_url: info.base_url.clone(),
+            auth: auth_header(info),
+        }
+    }
+
+    fn req(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
+        let mut r = self.http.request(method, format!("{}{}", self.base_url, path));
+        if let Some(auth) = &self.auth {
+            r = r.header(reqwest::header::AUTHORIZATION, auth);
+        }
+        r
+    }
+
+    async fn send_json(&self, rb: reqwest::RequestBuilder, ctx: &str) -> Result<Value, super::HttpError> {
+        let resp = rb
+            .send()
+            .await
+            .map_err(|e| super::HttpError::Transport(format!("{ctx}: {e}")))?;
+        let status = resp.status();
+        let body: Value = if status == reqwest::StatusCode::NO_CONTENT {
+            Value::Null
+        } else {
+            resp.json()
+                .await
+                .map_err(|e| super::HttpError::Transport(format!("{ctx}: bad json: {e}")))?
+        };
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(super::HttpError::NotFound(ctx.to_string()));
+        }
+        if !status.is_success() {
+            return Err(super::HttpError::Api {
+                status: status.as_u16(),
+                ctx: ctx.to_string(),
+                body,
+            });
+        }
+        Ok(body)
+    }
+
+    /// `POST /api/session` → (session_id, project_id). `directory` is the
+    /// session's working directory (the API's per-session workspace pin).
+    pub async fn create_session(&self, directory: &str) -> Result<(String, String), super::HttpError> {
+        let body = json!({ "location": { "directory": directory } });
+        let v = self
+            .send_json(
+                self.req(reqwest::Method::POST, "/api/session").json(&body),
+                "POST /api/session",
+            )
+            .await?;
+        let id = v
+            .pointer("/data/id")
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| super::HttpError::Transport("session create: no data.id".into()))?
+            .to_string();
+        let project = v
+            .pointer("/data/projectID")
+            .and_then(|s| s.as_str())
+            .unwrap_or("global")
+            .to_string();
+        Ok((id, project))
+    }
+
+    /// `GET /api/session/{id}` — existence probe for resume.
+    pub async fn get_session(&self, id: &str) -> Result<Value, super::HttpError> {
+        self.send_json(
+            self.req(reqwest::Method::GET, &format!("/api/session/{id}")),
+            "GET /api/session/{id}",
+        )
+        .await
+    }
+
+    /// `POST /api/session/{id}/prompt` — durably admits (and, with
+    /// `delivery:"steer"`, schedules) the agent loop. Returns the input's
+    /// (session, message id, admittedSeq).
+    pub async fn prompt(&self, session_id: &str, text: &str) -> Result<PromptAdmit, super::HttpError> {
+        let body = json!({
+            "prompt": { "text": text },
+            "delivery": "steer",
+        });
+        let v = self
+            .send_json(
+                self.req(reqwest::Method::POST, &format!("/api/session/{session_id}/prompt"))
+                    .json(&body),
+                "POST prompt",
+            )
+            .await?;
+        Ok(PromptAdmit {
+            id: v
+                .pointer("/data/id")
+                .and_then(|s| s.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            admitted_seq: v.pointer("/data/admittedSeq").and_then(|s| s.as_u64()),
+        })
+    }
+
+    /// `POST /api/session/{id}/interrupt` — abort the running turn (204).
+    pub async fn interrupt(&self, session_id: &str) -> Result<(), super::HttpError> {
+        self.send_json(
+            self.req(reqwest::Method::POST, &format!("/api/session/{session_id}/interrupt")),
+            "POST interrupt",
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// `POST /api/session/{id}/model` — switch the session model
+    /// (`{"model":{"id","providerID"}}`, 204).
+    pub async fn set_model(&self, session_id: &str, model: &str) -> Result<(), super::HttpError> {
+        let (provider, id) = split_model(model);
+        let body = json!({ "model": { "id": id, "providerID": provider } });
+        self.send_json(
+            self.req(reqwest::Method::POST, &format!("/api/session/{session_id}/model"))
+                .json(&body),
+            "POST model",
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// `GET /api/session/active` → true when `session_id` currently drains a
+    /// foreground execution (the turn-in-flight ground truth; `/wait` is a
+    /// 503 stub in 1.18.30, so the backend polls this to close a turn).
+    pub async fn session_active(&self, session_id: &str) -> Result<bool, super::HttpError> {
+        let v = self
+            .send_json(
+                self.req(reqwest::Method::GET, "/api/session/active"),
+                "GET /api/session/active",
+            )
+            .await?;
+        Ok(v.get("data").and_then(|d| d.get(session_id)).is_some())
+    }
+
+    /// `GET /api/session/{id}/permission?limit=…` pending permission list.
+    pub async fn pending_permissions(&self, session_id: &str) -> Vec<Value> {
+        match self
+            .send_json(
+                self.req(reqwest::Method::GET, &format!("/api/session/{session_id}/permission")),
+                "GET permissions",
+            )
+            .await
+        {
+            Ok(v) => data_array(v),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// `POST /api/session/{id}/permission/{request_id}/reply`.
+    pub async fn reply_permission(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        reply: &str,
+    ) -> Result<(), super::HttpError> {
+        let body = json!({ "reply": reply });
+        self.send_json(
+            self.req(
+                reqwest::Method::POST,
+                &format!("/api/session/{session_id}/permission/{request_id}/reply"),
+            )
+            .json(&body),
+            "POST permission reply",
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// `GET /api/session/{id}/question` pending question list.
+    pub async fn pending_questions(&self, session_id: &str) -> Vec<Value> {
+        match self
+            .send_json(
+                self.req(reqwest::Method::GET, &format!("/api/session/{session_id}/question")),
+                "GET questions",
+            )
+            .await
+        {
+            Ok(v) => data_array(v),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// `POST /api/session/{id}/question/{request_id}/reply` —
+    /// `answers` must be an ARRAY of string arrays (one per question, see
+    /// QuestionV2.Answer; a flat string array 400s).
+    pub async fn reply_question(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        answers: Vec<Vec<String>>,
+    ) -> Result<(), super::HttpError> {
+        let body = json!({ "answers": answers });
+        self.send_json(
+            self.req(
+                reqwest::Method::POST,
+                &format!("/api/session/{session_id}/question/{request_id}/reply"),
+            )
+            .json(&body),
+            "POST question reply",
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// `POST /api/session/{id}/question/{request_id}/reject`.
+    pub async fn reject_question(&self, session_id: &str, request_id: &str) -> Result<(), super::HttpError> {
+        self.send_json(
+            self.req(
+                reqwest::Method::POST,
+                &format!("/api/session/{session_id}/question/{request_id}/reject"),
+            ),
+            "POST question reject",
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// `GET /api/session/{id}/history?after=<exclusive seq>` — pages are
+    /// hard-capped at 100 (limit>100 → 400, confirmed live), so page until
+    /// `hasMore` is false; returns (events newest-last, last durable seq seen).
+    pub async fn history_tail(&self, session_id: &str) -> Vec<StreamEvent> {
+        let mut out = Vec::new();
+        let mut after: i64 = 0; // exclusive; durable seqs start at 1
+        loop {
+            let path = format!("/api/session/{session_id}/history?limit=100&after={after}");
+            let Ok(v) = self
+                .send_json(self.req(reqwest::Method::GET, &path), "GET history")
+                .await
+            else {
+                break;
+            };
+            let page = data_array(v.clone());
+            let has_more = v.get("hasMore").and_then(|h| h.as_bool()).unwrap_or(false);
+            let mut max = after;
+            for ev in &page {
+                if let Some(seq) = ev.get("durable").and_then(|d| d.get("seq")).and_then(|s| s.as_u64()) {
+                    max = max.max(seq as i64);
+                }
+                if let Some(se) = sse_data_to_event(ev.clone()) {
+                    out.push(se);
+                }
+            }
+            if !has_more || page.is_empty() {
+                break;
+            }
+            after = max;
+        }
+        out
+    }
+
+    /// `GET /api/session/{id}/event?after=<seq>` — durable + transient SSE.
+    /// Resumable by durable seq (replay verified across server restarts).
+    /// Returns a stream of raw JSON records; the caller parses via
+    /// [`sse_data_to_event`].
+    pub async fn event_stream(
+        &self,
+        session_id: &str,
+        after: Option<u64>,
+    ) -> Result<reqwest::Response, super::HttpError> {
+        let path = match after {
+            Some(a) => format!("/api/session/{session_id}/event?after={a}"),
+            None => format!("/api/session/{session_id}/event"),
+        };
+        // No client timeout on the stream: the pooled 30s client would kill
+        // an idle SSE, so connect with a dedicated no-timeout client.
+        let stream_client = SSE_CLIENT.get_or_init(|| {
+            reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("sse reqwest client")
+        });
+        let mut req2 = stream_client
+            .get(format!("{}{}", self.base_url, path))
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        if let Some(auth) = &self.auth {
+            req2 = req2.header(reqwest::header::AUTHORIZATION, auth);
+        }
+        let resp = req2
+            .send()
+            .await
+            .map_err(|e| super::HttpError::Transport(format!("sse connect: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(super::HttpError::Api {
+                status: resp.status().as_u16(),
+                ctx: "GET event".into(),
+                body: Value::Null,
+            });
+        }
+        Ok(resp)
+    }
+}
+
+pub struct PromptAdmit {
+    pub id: String,
+    pub admitted_seq: Option<u64>,
+}
+
+/// `provider/model` → (providerID, modelID); no slash keeps the whole string
+/// as modelID (the server then resolves its configured default provider).
+pub fn split_model(model: &str) -> (String, String) {
+    match model.split_once('/') {
+        Some((p, m)) if !p.is_empty() && !m.is_empty() => (p.to_string(), m.to_string()),
+        _ => (String::new(), model.to_string()),
+    }
+}
+
+fn data_array(v: Value) -> Vec<Value> {
+    match v.get("data") {
+        Some(Value::Array(a)) => a.clone(),
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_model_provider_slash() {
+        assert_eq!(
+            split_model("opencode/big-pickle"),
+            ("opencode".into(), "big-pickle".into())
+        );
+        assert_eq!(
+            split_model("gzbit/qwen3.8-flash-next"),
+            ("gzbit".into(), "qwen3.8-flash-next".into())
+        );
+        // No slash → whole string is the model id, provider left blank so the
+        // server falls back to its configured default.
+        assert_eq!(split_model("solo"), (String::new(), "solo".into()));
+        // Edge: leading slash must not invent an empty provider name…
+        assert_eq!(split_model("/x"), (String::new(), "/x".into()));
+        // …nor trailing slash an empty model.
+        assert_eq!(split_model("p/"), (String::new(), "p/".into()));
+        // Multi-slash model ids keep the FIRST slash as the boundary.
+        assert_eq!(
+            split_model("openrouter/meta-llama/llama-3"),
+            ("openrouter".into(), "meta-llama/llama-3".into())
+        );
+    }
+
+    #[test]
+    fn sse_event_parses_durable_envelope() {
+        let v: Value = serde_json::from_str(
+            r#"{"id":"evt1","type":"session.next.text.delta","durable":{"aggregateID":"ses_x","seq":12},"data":{"textID":"t1","delta":"hi"}}"#,
+        )
+        .unwrap();
+        let ev = sse_data_to_event(v).unwrap();
+        assert_eq!(ev.event_type, "session.next.text.delta");
+        assert_eq!(ev.seq, Some(12));
+        assert_eq!(ev.data["delta"], "hi");
+    }
+
+    #[test]
+    fn sse_event_without_durable_is_transient() {
+        let v: Value = serde_json::from_str(r#"{"type":"session.idle","data":{"sessionID":"ses_x"}}"#).unwrap();
+        let ev = sse_data_to_event(v).unwrap();
+        assert_eq!(ev.event_type, "session.idle");
+        assert_eq!(ev.seq, None);
+    }
+
+    #[test]
+    fn sse_event_missing_type_is_none() {
+        let v: Value = serde_json::from_str(r#"{"data":{}}"#).unwrap();
+        assert!(sse_data_to_event(v).is_none());
+    }
+}

--- a/crates/aionui-ai-agent/src/opencode_shared/mod.rs
+++ b/crates/aionui-ai-agent/src/opencode_shared/mod.rs
@@ -1,0 +1,71 @@
+//! Shared-process opencode backend (one `opencode serve` for ALL opencode
+//! conversations in this AionUi instance).
+//!
+//! * [`pool`] — lifecycle of the single shared `opencode serve` (discover →
+//!   adopt → spawn; refcount; never kills a foreign server).
+//! * [`client`] — typed V2 HTTP/SSE client (endpoints + payloads verified
+//!   live against opencode 1.18.30 `/doc`).
+//! * [`translate`] — durable/SSE event → `SessionEvent` mapping.
+//! * [`backend`] — `BackendConnection`/`SessionBackend` implementation the
+//!     factory wires into `AgentInstance::Session`.
+//!
+//! Enabled via the environment: `AIONUI_OPENCODE_SHARED_SERVER=1` (opt-in;
+//! unset/`0` keeps the battle-tested per-conversation `opencode acp` ACP path
+//! untouched, including its per-conversation `AIONUI_*` identity env).
+
+mod backend;
+mod client;
+mod pool;
+mod translate;
+
+pub use backend::{OpencodeConnection, OpencodeSessionBackend, opencode_capabilities};
+pub use client::OpencodeClient;
+pub use pool::{ServerLease, global_pool};
+
+use serde_json::Value;
+
+/// Toggle for shared-server mode. Opt-in: `AIONUI_OPENCODE_SHARED_SERVER`
+/// set to `1`/`true`/`on`/`yes` (case-insensitive). Anything else keeps the
+/// legacy ACP spawn path.
+pub fn shared_server_enabled() -> bool {
+    matches!(
+        std::env::var("AIONUI_OPENCODE_SHARED_SERVER")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// Error surface for the typed client; stringified into `BackendError`s by
+/// the backend.
+#[derive(Debug)]
+pub enum HttpError {
+    /// Connect/timeout/bad-json style failures.
+    Transport(String),
+    /// The endpoint answered 404 (e.g. session anchor gone after storage
+    /// wipe) — callers map this to typed outcomes.
+    NotFound(String),
+    /// Non-2xx with a JSON body (opencode errors are `{name,message,…}`).
+    Api { status: u16, ctx: String, body: Value },
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HttpError::Transport(m) => write!(f, "transport: {m}"),
+            HttpError::NotFound(c) => write!(f, "404: {c}"),
+            HttpError::Api { status, ctx, body } => {
+                let brief = body
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| body.to_string());
+                write!(f, "{status} {ctx}: {brief}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HttpError {}

--- a/crates/aionui-ai-agent/src/opencode_shared/pool.rs
+++ b/crates/aionui-ai-agent/src/opencode_shared/pool.rs
@@ -1,0 +1,529 @@
+//! Shared `opencode serve` process pool (PR: single-process opencode mode).
+//!
+//! Motivation: the legacy path spawns one `opencode acp` process PER
+//! conversation, and each of those boots its own embedded HTTP server. N
+//! concurrent opencode conversations therefore cost N bun processes (hundreds
+//! of MB each). The `opencode serve` HTTP/SSE API, in contrast, is designed
+//! to host an arbitrary number of sessions across arbitrary working
+//! directories concurrently (one `location.directory` per session), so ALL
+//! opencode conversations in one AionUi instance attach to ONE shared server.
+//!
+//! Lifecycle (mirrors what OpenChamber's VSCode extension does):
+//! 1. Discovery — a registry file under the OS temp dir remembers the last
+//!    spawned server (`port`/`password`/`pid`/`program`). On first use after an
+//!    AionUi restart we probe it and adopt it if it answers `/api/health`.
+//! 2. Adopt-foreign — if any server already answers `/api/health` on the
+//!    registry port without auth, it is adopted READ-ONLY (never killed).
+//! 3. Spawn-if-absent — bind port 0 to let the OS pick a free port (an
+//!    explicit `--port` also defeats any user-pinned `server.port` in
+//!    `~/.config/opencode/opencode.json`), spawn
+//!    `opencode serve --hostname 127.0.0.1 --port N` with a self-generated
+//!    `OPENCODE_SERVER_PASSWORD`, poll `/api/health` until ready.
+//! 4. Reference counting — every attached conversation holds a
+//!    [`ServerLease`]; the last lease dropping tears down OUR server (never a
+//!    foreign one). A background watchdog marks the entry dead when the health
+//!    probe fails repeatedly so attached sessions learn about a crash via
+//!    their `watch` receiver and emit `Detached`.
+//!
+//! Known limitation (documented in the PR): the shared process cannot carry
+//! per-conversation `AIONUI_CONVERSATION_ID` env — it is stripped from the
+//! spawn env so helper-CLI features fail loudly instead of misattributing.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, watch};
+
+/// A resident shared server. Cheap to clone; all fields describe one
+/// `opencode serve` process the pool either owns or adopted.
+#[derive(Debug, Clone)]
+pub struct ServerInfo {
+    pub base_url: String,
+    /// Basic-auth password we generated (own servers), or `None` for a
+    /// foreign server that serves unauthenticated.
+    pub password: Option<String>,
+    pub pid: Option<u32>,
+    /// True when the server was NOT spawned by this pool (never killed).
+    pub external: bool,
+}
+
+/// What the pool mutates per registry key.
+struct Entry {
+    info: ServerInfo,
+    refs: usize,
+    alive_tx: watch::Sender<bool>,
+    /// Abort handle for the watchdog task (so teardown can stop it).
+    watchdog: tokio::task::JoinHandle<()>,
+}
+
+/// Registry key. One shared server per program binary — in practice a single
+/// entry; keyed so two different opencode builds don't fight over one slot.
+type PoolKey = String;
+
+#[derive(Default)]
+struct PoolState {
+    entries: HashMap<PoolKey, Entry>,
+}
+
+/// Process-wide pool. AionUi runs one aioncore, so global state is fine;
+/// cross-process sharing is handled via the registry file + health probe.
+static POOL: std::sync::OnceLock<Arc<ServerPool>> = std::sync::OnceLock::new();
+
+pub fn global_pool() -> Arc<ServerPool> {
+    POOL.get_or_init(|| Arc::new(ServerPool::default())).clone()
+}
+
+#[derive(Default)]
+pub struct ServerPool {
+    state: Mutex<PoolState>,
+}
+
+/// RAII lease: one attached conversation. Cloning a lease would double-count,
+/// so callers share `Arc<ServerLease>` instead.
+pub struct ServerLease {
+    pub info: ServerInfo,
+    pool: Arc<ServerPool>,
+    key: PoolKey,
+}
+
+impl Clone for ServerLease {
+    fn clone(&self) -> Self {
+        // Only ever reached through Arc; still keep accounting honest.
+        self.pool.clone_lease(&self.key);
+        Self {
+            info: self.info.clone(),
+            pool: self.pool.clone(),
+            key: self.key.clone(),
+        }
+    }
+}
+
+impl Drop for ServerLease {
+    fn drop(&mut self) {
+        let pool = self.pool.clone();
+        let key = self.key.clone();
+        // Release is async (pool mutex) and MAY end in killing the server, so
+        // it must survive the caller's runtime going away: a lease dropped
+        // during runtime shutdown (test teardown, task aborts) would silently
+        // lose an `Handle::spawn` and leak the process. A detached OS thread
+        // with a private current-thread runtime makes the last-lease teardown
+        // unconditional. (No lock is held across Drop; this is fire-and-forget
+        // and a lost decrement would still self-heal via the watchdog.)
+        std::thread::spawn(move || {
+            if let Ok(rt) = tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                rt.block_on(pool.release(&key));
+            }
+        });
+    }
+}
+
+/// Registry file location: `%TEMP%/aionui-opencode-shared/<hash>.json`.
+fn registry_path(program: &Path) -> PathBuf {
+    let digest = {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        program.to_string_lossy().to_lowercase().hash(&mut h);
+        format!("{:016x}", h.finish())
+    };
+    std::env::temp_dir()
+        .join("aionui-opencode-shared")
+        .join(format!("{digest}.json"))
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct RegistryRecord {
+    port: u16,
+    password: String,
+    pid: u32,
+    program: String,
+}
+
+impl ServerPool {
+    /// Current live server info for `program` if the pool already hosts one
+    /// (same key as `acquire`: the lowercased program path). Used by the
+    /// shared-server tests to PROVE the one-process claim — two sessions must
+    /// observe the same base_url; handy for diagnostics too.
+    pub async fn peek(self: &Arc<Self>, program: &Path) -> Option<ServerInfo> {
+        let key = program.to_string_lossy().to_lowercase();
+        let state = self.state.lock().await;
+        state.entries.get(&key).map(|e| e.info.clone())
+    }
+
+    /// Acquire (adopt-or-spawn) the shared server for `program` and hold a
+    /// lease for it. `spawn_env` entries are EXTRA environment on top of the
+    /// inherited env; `AIONUI_CONVERSATION_ID` is always stripped (a shared
+    /// process must not impersonate one conversation).
+    pub async fn acquire(self: &Arc<Self>, program: &Path, spawn_env: &[(String, String)]) -> Result<Acquired, String> {
+        let key = program.to_string_lossy().to_lowercase();
+        loop {
+            let action = {
+                let mut st = self.state.lock().await;
+                match st.entries.get_mut(&key) {
+                    Some(e) if e.info.external => {
+                        // Re-validating an adopted foreign server on every
+                        // acquire is cheap; drop it if it stopped answering.
+                        if health_ok(&e.info).await {
+                            e.refs += 1;
+                            Some(Ok(mk_acquire(e, self, &key)))
+                        } else {
+                            let old = st.entries.remove(&key);
+                            if let Some(old) = old {
+                                old.watchdog.abort();
+                            }
+                            None
+                        }
+                    }
+                    Some(e) => {
+                        // Own server: trust liveness unless the watchdog said
+                        // dead; then reap and fall through to re-discover.
+                        if *e.alive_tx.borrow() && health_ok(&e.info).await {
+                            e.refs += 1;
+                            Some(Ok(mk_acquire(e, self, &key)))
+                        } else {
+                            let old = st.entries.remove(&key);
+                            if let Some(old) = old {
+                                old.watchdog.abort();
+                            }
+                            None
+                        }
+                    }
+                    None => None,
+                }
+            };
+            if let Some(result) = action {
+                return result;
+            }
+            // Not resident: discovery → adopt → spawn, all under the lock so
+            // racing callers queue instead of double-spawning.
+            let mut st = self.state.lock().await;
+            if st.entries.contains_key(&key) {
+                continue; // someone else just installed it while we unlocked
+            }
+            let info = discover_or_spawn(program, spawn_env).await?;
+            let (alive_tx, _rx) = watch::channel(true);
+            let watchdog = spawn_watchdog(info.clone(), alive_tx.clone());
+            st.entries.insert(
+                key.clone(),
+                Entry {
+                    info: info.clone(),
+                    refs: 1,
+                    alive_tx,
+                    watchdog,
+                },
+            );
+            let e = st.entries.get_mut(&key).expect("just inserted");
+            return Ok(mk_acquire(e, self, &key));
+        }
+    }
+
+    fn clone_lease(self: &Arc<Self>, key: &PoolKey) {
+        let pool = self.clone();
+        let key = key.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Some(e) = pool.state.lock().await.entries.get_mut(&key) {
+                    e.refs += 1;
+                }
+            });
+        }
+    }
+
+    async fn release(self: &Arc<Self>, key: &PoolKey) {
+        let victim = {
+            let mut st = self.state.lock().await;
+            let Some(e) = st.entries.get_mut(key) else { return };
+            e.refs = e.refs.saturating_sub(1);
+            if e.refs == 0 && !e.info.external {
+                st.entries.remove(key)
+            } else {
+                None
+            }
+        };
+        if let Some(e) = victim {
+            e.watchdog.abort();
+            let _ = e.alive_tx.send(false);
+            if let Some(pid) = e.info.pid {
+                kill_pid(pid);
+            }
+            let _ = std::fs::remove_file(registry_path(Path::new(key)));
+            tracing::info!(
+                port = e.info.base_url,
+                "opencode shared server stopped (last lease dropped)"
+            );
+        }
+    }
+}
+
+/// What a successful acquire hands to the backend: the lease plus a liveness
+/// watch (transitions to `false` when the server dies while attached — the
+/// backend turns that into `SessionEvent::Detached`).
+pub struct Acquired {
+    pub lease: Arc<ServerLease>,
+    pub alive: watch::Receiver<bool>,
+}
+
+fn mk_acquire(e: &mut Entry, pool: &Arc<ServerPool>, key: &PoolKey) -> Acquired {
+    let _ = e.refs; // already incremented by caller
+    Acquired {
+        lease: Arc::new(ServerLease {
+            info: e.info.clone(),
+            pool: pool.clone(),
+            key: key.clone(),
+        }),
+        alive: e.alive_tx.subscribe(),
+    }
+}
+
+/// Try the registry, then a silent adopt of any already-running server, then
+/// spawn our own. Never touches a server whose password we do not know.
+async fn discover_or_spawn(program: &Path, spawn_env: &[(String, String)]) -> Result<ServerInfo, String> {
+    let reg = registry_path(program);
+    // 1) Our own previous server (registry carries the password we gave it).
+    let mut hint_port: Option<u16> = None;
+    if let Ok(text) = std::fs::read_to_string(&reg)
+        && let Ok(rec) = serde_json::from_str::<RegistryRecord>(&text)
+    {
+        // A parseable record is stale unless it matches our program AND the
+        // health probe passes — anything else is removed before spawn.
+        if rec.program.to_lowercase() == program.to_string_lossy().to_lowercase() {
+            hint_port = Some(rec.port);
+            let info = ServerInfo {
+                base_url: format!("http://127.0.0.1:{}", rec.port),
+                password: Some(rec.password.clone()),
+                pid: Some(rec.pid),
+                external: false,
+            };
+            if health_ok(&info).await {
+                tracing::info!(port = rec.port, "opencode shared server adopted from registry");
+                return Ok(info);
+            }
+        }
+        let _ = std::fs::remove_file(&reg);
+    }
+    // 2) A server whose password we don't know — only adopt if it serves
+    //    UNAUTHENTICATED (user-launched `opencode serve` without a password):
+    //    the registry port (another AionUi may have taken the slot) and the
+    //    opencode default 4096. Adopted foreign servers are never killed.
+    let mut ports: Vec<u16> = Vec::new();
+    if let Some(p) = hint_port {
+        ports.push(p);
+    }
+    ports.push(4096);
+    for port in ports {
+        let info = ServerInfo {
+            base_url: format!("http://127.0.0.1:{port}"),
+            password: None,
+            pid: None,
+            external: true,
+        };
+        if health_ok(&info).await {
+            tracing::info!(port, "foreign auth-free opencode server adopted (read-only)");
+            return Ok(info);
+        }
+    }
+    // 3) Cold start: spawn our own, authenticated.
+    spawn_server(program, spawn_env, &reg).await
+}
+
+async fn spawn_server(program: &Path, spawn_env: &[(String, String)], reg: &Path) -> Result<ServerInfo, String> {
+    let port = reserve_free_port().await?;
+    let password = generate_password();
+    // npm-installed opencode ships a `.cmd` shim on Windows, which CreateProcess
+    // cannot launch directly. Same plan as `aionui-runtime::spawn`'s private
+    // `shell_wrap_windows_script`: `cmd /d /c <program> [args…]`. The pid recorded
+    // below is then cmd.exe's — `taskkill /T /F` kills the whole tree, and
+    // liveness is proven by the health probe, not the pid.
+    let mut pre_args: Vec<std::ffi::OsString> = Vec::new();
+    #[cfg(windows)]
+    {
+        let ext = program.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat") {
+            pre_args.push("/d".into());
+            pre_args.push("/c".into());
+            pre_args.push(program.as_os_str().to_owned());
+        }
+    }
+    let spawn_program: &std::ffi::OsStr = {
+        #[cfg(windows)]
+        {
+            let ext = program.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat") {
+                std::ffi::OsStr::new("cmd")
+            } else {
+                program.as_os_str()
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            program.as_os_str()
+        }
+    };
+    let mut cmd = tokio::process::Command::new(spawn_program);
+    cmd.args(&pre_args)
+        .args(["serve", "--hostname", "127.0.0.1", "--port", &port.to_string()])
+        .env("OPENCODE_SERVER_PASSWORD", &password)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    for (k, v) in spawn_env {
+        if k == "AIONUI_CONVERSATION_ID" || k == "OPENCODE_SERVER_PASSWORD" {
+            continue; // shared process: no per-conversation identity, own auth
+        }
+        cmd.env(k, v);
+    }
+    #[cfg(windows)]
+    {
+        // tokio::process::Command exposes creation_flags as an inherent
+        // method on Windows — no CommandExt trait import needed.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn `{} serve`: {e}", program.display()))?;
+    let pid = child.id();
+    let info = ServerInfo {
+        base_url: format!("http://127.0.0.1:{port}"),
+        password: Some(password.clone()),
+        pid,
+        external: false,
+    };
+    // Readiness: poll /api/health up to ~90s (bun cold start can be slow on
+    // Windows AV scanners, and bundled/distribution exe wrappers are slower
+    // still). Timeouts here surface as a startup failure the same way the ACP
+    // handshake timeout would.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(90);
+    loop {
+        if health_ok(&info).await {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            if let Some(pid) = pid {
+                kill_pid(pid);
+            }
+            return Err(format!(
+                "opencode serve on port {port} did not become healthy within 90s \
+                 (is `{}` a `serve`-capable opencode ≥ 1.18?)",
+                program.display()
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+    }
+    // Persist BEFORE handing out the lease: a crash right after must still
+    // find (and clean) the record. Detach the child so dropping the Command
+    // does not kill it (kill_on_drop defaults to false).
+    let rec = RegistryRecord {
+        port,
+        password,
+        pid: pid.unwrap_or(0),
+        program: program.to_string_lossy().into_owned(),
+    };
+    if let Some(dir) = reg.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(reg, serde_json::to_string(&rec).unwrap_or_default());
+    tracing::info!(port, ?pid, "opencode shared server ready");
+    Ok(info)
+}
+
+async fn reserve_free_port() -> Result<u16, String> {
+    let l = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("reserve free port: {e}"))?;
+    let port = l.local_addr().map_err(|e| format!("local addr: {e}"))?.port();
+    drop(l); // release so `serve --port` can bind it
+    Ok(port)
+}
+
+fn generate_password() -> String {
+    // getrandom is a direct dep of this crate (used by the ACP auth tokens).
+    let mut a = [0u8; 16];
+    let mut b = [0u8; 16];
+    let _ = getrandom::getrandom(&mut a);
+    let _ = getrandom::getrandom(&mut b);
+    format!("{}{}", hex(&a), hex(&b))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub(crate) fn auth_header(info: &ServerInfo) -> Option<String> {
+    info.password.as_ref().map(|pw| {
+        use base64::Engine;
+        format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(format!("opencode:{pw}"))
+        )
+    })
+}
+
+async fn health_ok(info: &ServerInfo) -> bool {
+    health_ok_with(&shared_client(), info).await
+}
+
+async fn health_ok_with(client: &reqwest::Client, info: &ServerInfo) -> bool {
+    let mut req = client.get(format!("{}/api/health", info.base_url));
+    if let Some(auth) = auth_header(info) {
+        req = req.header(reqwest::header::AUTHORIZATION, auth);
+    }
+    match req.send().await {
+        Ok(r) => r.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+/// Shared HTTP client (connection pooling across all sessions). Long-ish
+/// timeouts are per-request at the call sites; SSE uses its own no-timeout
+/// client inside the backend pump.
+pub fn shared_client() -> reqwest::Client {
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("reqwest client")
+        })
+        .clone()
+}
+
+static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
+fn spawn_watchdog(info: ServerInfo, alive_tx: watch::Sender<bool>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut misses = 0u32;
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+            if health_ok(&info).await {
+                misses = 0;
+                continue;
+            }
+            misses += 1;
+            if misses >= 2 {
+                tracing::warn!(base = %info.base_url, "opencode shared server lost (health failed)");
+                let _ = alive_tx.send(false);
+                return;
+            }
+        }
+    })
+}
+
+fn kill_pid(pid: u32) {
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+}

--- a/crates/aionui-ai-agent/src/opencode_shared/translate.rs
+++ b/crates/aionui-ai-agent/src/opencode_shared/translate.rs
@@ -1,0 +1,643 @@
+//! opencode durable/SSE event → `SessionEvent` translation.
+//!
+//! Every mapping here is backed by a live capture against `opencode serve`
+//! 1.18.30 (see the PR description). Key contracts:
+//!
+//! * Durable envelope: `{id, type, durable:{aggregateID, seq, version}, data}`
+//!   delivered as one `data:` SSE line; transient events (e.g. `session.idle`)
+//!   share the shape minus `durable`.
+//! * Text/reasoning arrive as `*.started` / `*.delta` / `*.ended` with
+//!   `textID`/`reasoningID`; `*.ended` carries the FULL text, so when no
+//!   delta streamed (tiny/fast answers) we emit the complete text once at
+//!   ended — never duplicates, never losses.
+//! * Tools arrive pre-ordered `tool.input.started → tool.input.delta* →
+//!   tool.input.ended → tool.called → tool.success|tool.failed`; input JSON is
+//!   finalized by `tool.input.ended`, so one `ToolCall` goes out on `.called`.
+//! * `session.next.step.ended{finish,cost,tokens}` is PER LLM step
+//!   (`finish:"tool-calls"` continues the loop — NOT turn end); the
+//!   authoritative turn-end signal is the session leaving
+//!   `GET /api/session/active` (captured behavior), backed by the transient
+//!   `session.idle`/`session.error` if the server sends one.
+//! * Permission/question CARDS come from the pending-list poller (authoritative
+//!   `GET /api/session/{id}/permission|question`), because a turn blocked on
+//!   approval emits nothing durable (captured); `*.replied/rejected` resolve
+//!   events do stream and are mapped here.
+
+use std::collections::HashMap;
+
+use aionui_session::{
+    CancelReason, NoticeLevel, PermissionKind, SessionEvent, StopReason, SubagentKind, ToolResultContent, TurnOutcome,
+    UsageBreakdown,
+};
+use serde_json::{Value, json};
+
+use super::client::StreamEvent;
+
+/// Per-conversation translation state. The orchestrator guarantees one
+/// turn-at-a-time, so a single set of turn accumulators suffices.
+#[derive(Default)]
+pub struct TranslateState {
+    /// textID → bytes already emitted from deltas.
+    streamed_text: HashMap<String, usize>,
+    /// reasoningID → bytes already emitted from deltas.
+    streamed_reasoning: HashMap<String, usize>,
+    /// callID → (tool name, finalized input JSON).
+    tool_inputs: HashMap<String, (String, Option<Value>)>,
+    /// Turn usage totals (sum over `step.ended` frames).
+    turn_input_tokens: u64,
+    turn_output_tokens: u64,
+    turn_thought_tokens: u64,
+    turn_cache_read: u64,
+    turn_cache_write: u64,
+    turn_cost_usd: f64,
+}
+
+impl TranslateState {
+    /// Reset turn-scoped state at a NEW turn (dispatch Send).
+    pub fn begin_turn(&mut self) {
+        *self = TranslateState::default();
+    }
+
+    pub fn turn_usage_event(&self) -> SessionEvent {
+        SessionEvent::UsageDelta {
+            input_tokens: self.turn_input_tokens,
+            output_tokens: self.turn_output_tokens,
+            total_tokens: self.turn_input_tokens + self.turn_output_tokens,
+            cost_usd: if self.turn_cost_usd > 0.0 {
+                Some(self.turn_cost_usd)
+            } else {
+                None
+            },
+            breakdown: UsageBreakdown {
+                cached_read_tokens: self.turn_cache_read,
+                cached_write_tokens: self.turn_cache_write,
+                thought_tokens: self.turn_thought_tokens,
+            },
+            context_window: None,
+        }
+    }
+}
+
+fn s(v: &Value, key: &str) -> String {
+    v.get(key).and_then(|x| x.as_str()).unwrap_or_default().to_string()
+}
+
+fn req_id(d: &Value) -> String {
+    let id = s(d, "requestID");
+    if id.is_empty() { s(d, "id") } else { id }
+}
+
+/// Translate one opencode stream event into zero or more SessionEvents.
+pub fn translate(ev: &StreamEvent, st: &mut TranslateState) -> Vec<SessionEvent> {
+    let d = &ev.data;
+    match ev.event_type.as_str() {
+        // ── assistant text ─────────────────────────────────────────────
+        "session.next.text.delta" => {
+            let delta = s(d, "delta");
+            if delta.is_empty() {
+                return Vec::new();
+            }
+            *st.streamed_text.entry(s(d, "textID")).or_default() += delta.len();
+            vec![SessionEvent::MessageDelta {
+                item_id: format!("msg-{}", s(d, "textID")),
+                text: delta,
+            }]
+        }
+        "session.next.text.ended" => {
+            let text = s(d, "text");
+            let id = s(d, "textID");
+            let seen = st.streamed_text.remove(&id).unwrap_or(0);
+            // Nothing streamed for this textID → the full text exists only
+            // here (fast answers never stream deltas) → emit once.
+            if !text.is_empty() && seen == 0 {
+                vec![SessionEvent::MessageDelta {
+                    item_id: format!("msg-{id}"),
+                    text,
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+        // ── reasoning ──────────────────────────────────────────────────
+        "session.next.reasoning.delta" => {
+            let delta = s(d, "delta");
+            if delta.is_empty() {
+                return Vec::new();
+            }
+            *st.streamed_reasoning.entry(s(d, "reasoningID")).or_default() += delta.len();
+            vec![SessionEvent::ThoughtDelta {
+                item_id: format!("thought-{}", s(d, "reasoningID")),
+                text: delta,
+            }]
+        }
+        "session.next.reasoning.ended" => {
+            let text = s(d, "text");
+            let id = s(d, "reasoningID");
+            let seen = st.streamed_reasoning.remove(&id).unwrap_or(0);
+            if !text.is_empty() && seen == 0 {
+                vec![SessionEvent::ThoughtDelta {
+                    item_id: format!("thought-{id}"),
+                    text,
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+        // ── steps ──────────────────────────────────────────────────────
+        "session.next.step.ended" => {
+            // Usage accounting only; TURN END is decided by the active-map
+            // poller, never here (`finish:"tool-calls"` continues the agent
+            // loop, and even "stop" needs the settle grace for trailing
+            // frames — captured behavior of 1.18.30).
+            let tokens = d.get("tokens").cloned().unwrap_or(json!({}));
+            let g = |keys: &[&str]| -> u64 {
+                keys.iter()
+                    .find_map(|k| tokens.get(*k).and_then(|v| v.as_u64()))
+                    .unwrap_or(0)
+            };
+            st.turn_input_tokens += g(&["input"]);
+            st.turn_output_tokens += g(&["output"]);
+            st.turn_thought_tokens += g(&["reasoning"]);
+            if let Some(c) = tokens.get("cache") {
+                st.turn_cache_read += c.get("read").and_then(|v| v.as_u64()).unwrap_or(0);
+                st.turn_cache_write += c.get("write").and_then(|v| v.as_u64()).unwrap_or(0);
+            }
+            if let Some(c) = d.get("cost").and_then(|v| v.as_f64()) {
+                st.turn_cost_usd += c;
+            }
+            Vec::new()
+        }
+        // ── tools ──────────────────────────────────────────────────────
+        "session.next.tool.input.started" => {
+            st.tool_inputs.insert(s(d, "callID"), (s(d, "name"), None));
+            Vec::new()
+        }
+        "session.next.tool.input.ended" => {
+            let call_id = s(d, "callID");
+            let raw = s(d, "text");
+            let parsed: Option<Value> = serde_json::from_str(&raw).ok();
+            let entry = st.tool_inputs.entry(call_id).or_insert_with(|| (String::new(), None));
+            if entry.0.is_empty() {
+                entry.0 = s(d, "name");
+            }
+            entry.1 = Some(parsed.unwrap_or_else(|| json!({ "raw": raw })));
+            Vec::new()
+        }
+        "session.next.tool.called" => {
+            let call_id = s(d, "callID");
+            let streamed = st.tool_inputs.get(&call_id).cloned();
+            let name = match (&streamed, d.get("tool").and_then(|t| t.as_str())) {
+                (Some((n, _)), None) | (Some((n, _)), Some("")) => n.clone(),
+                (_, Some(t)) if !t.is_empty() => t.to_string(),
+                (Some((n, _)), _) => n.clone(),
+                (None, _) => String::new(),
+            };
+            let input = streamed
+                .and_then(|(_, i)| i)
+                .or_else(|| d.get("input").cloned())
+                .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+            vec![SessionEvent::ToolCall {
+                tool_use_id: call_id,
+                name,
+                // Subagent framing is out of scope: opencode `task` spawns
+                // NESTED sessions (own session ids), not claude-style inline
+                // subagents — the tool result still surfaces either way.
+                subagent: SubagentKind::default(),
+                input,
+                parent_tool_use_id: None,
+            }]
+        }
+        "session.next.tool.success" => {
+            let text = tool_output_text(d);
+            vec![SessionEvent::ToolResult {
+                tool_use_id: s(d, "callID"),
+                is_error: false,
+                content: vec![ToolResultContent::Text(text)],
+                parent_tool_use_id: None,
+            }]
+        }
+        "session.next.tool.failed" => {
+            let msg = d
+                .get("error")
+                .map(|e| {
+                    e.get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("tool failed")
+                        .to_string()
+                })
+                .unwrap_or_else(|| "tool failed".to_string());
+            vec![SessionEvent::ToolResult {
+                tool_use_id: s(d, "callID"),
+                is_error: true,
+                content: vec![ToolResultContent::Text(msg)],
+                parent_tool_use_id: None,
+            }]
+        }
+        "session.next.tool.progress" => vec![SessionEvent::Heartbeat],
+        // ── permission / question resolves (asks come from the poller) ──
+        "permission.v2.replied" | "permission.v2.rejected" => {
+            let request_id = req_id(d);
+            if request_id.is_empty() {
+                return Vec::new();
+            }
+            vec![SessionEvent::PermissionResolved {
+                request_id,
+                kind: PermissionKind::Tool,
+            }]
+        }
+        "question.v2.replied" | "question.v2.rejected" => {
+            let request_id = req_id(d);
+            if request_id.is_empty() {
+                return Vec::new();
+            }
+            vec![SessionEvent::AskResolved { request_id }]
+        }
+        // ── errors / retry advisories ──────────────────────────────────
+        "session.error" => {
+            let msg = d
+                .get("error")
+                .map(|e| {
+                    e.get("data")
+                        .and_then(|x| x.get("message"))
+                        .and_then(|m| m.as_str())
+                        .or_else(|| e.as_str())
+                        .unwrap_or("session error")
+                        .to_string()
+                })
+                .unwrap_or_else(|| "session error".to_string());
+            // The CALLER promotes this to a failed TurnResult when a turn is
+            // in flight (it is also the turn-end signal on that path).
+            vec![SessionEvent::Notice {
+                level: NoticeLevel::Warning,
+                message: msg,
+                localized: None,
+                supersedes_key: None,
+            }]
+        }
+        "session.next.retried" => {
+            let reason = d
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .unwrap_or("retrying");
+            vec![SessionEvent::Notice {
+                level: NoticeLevel::Info,
+                message: format!("provider retry: {reason}"),
+                localized: None,
+                // Successive retries replace one card (codex-retry pattern the
+                // UI already understands).
+                supersedes_key: Some("opencode-retry".into()),
+            }]
+        }
+        // Everything else (prompt.admitted/prompted echoes — Send already owns
+        // those; step.started bookkeeping; session.updated/moved; todo.*;
+        // model/agent switch confirmations — ConfigChanged rides the
+        // dispatch receipt instead; unknown future events) produces nothing.
+        _ => Vec::new(),
+    }
+}
+
+/// Flatten `content[]` text parts, falling back to compact structured output.
+fn tool_output_text(d: &Value) -> String {
+    let mut out = String::new();
+    if let Some(parts) = d.get("content").and_then(|c| c.as_array()) {
+        for p in parts {
+            if let Some(t) = p.get("text").and_then(|t| t.as_str()) {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(t);
+            }
+        }
+    }
+    if out.is_empty()
+        && let Some(su) = d.get("structured")
+        && !su.is_null()
+    {
+        out = serde_json::to_string(su).unwrap_or_default();
+    }
+    out
+}
+
+/// Build the terminal event once the active-map poller (or a transient
+/// `session.idle`) confirms completion.
+pub fn turn_result_event(usage_turn_failed: bool, cancelled: bool) -> SessionEvent {
+    SessionEvent::TurnResult {
+        is_error: usage_turn_failed,
+        api_error_status: None,
+        // opencode has no turn-level summary string; the streamed MessageDelta
+        // text IS the answer and the finalizer folds it. "" = empty-turn.
+        result_text: String::new(),
+        // Stamped with the live epoch by the dispatch machinery that owns the
+        // turn; cancelled turns ride it too so the reducer's epoch guard drops
+        // the flushed late result instead of mislabelling the NEXT turn.
+        epoch: 0,
+        outcome: if cancelled {
+            TurnOutcome::Cancelled {
+                reason: CancelReason::UserCancel,
+            }
+        } else {
+            TurnOutcome::Completed {
+                stop_reason: StopReason::EndTurn,
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(type_: &str, data: Value) -> StreamEvent {
+        StreamEvent {
+            seq: Some(1),
+            event_type: type_.into(),
+            data,
+        }
+    }
+
+    #[test]
+    fn text_deltas_then_end_no_dupes() {
+        let mut st = TranslateState::default();
+        let a = translate(
+            &ev("session.next.text.delta", json!({"textID":"t1","delta":"Hello "})),
+            &mut st,
+        );
+        let b = translate(
+            &ev("session.next.text.delta", json!({"textID":"t1","delta":"world"})),
+            &mut st,
+        );
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        // ended carries the FULL text; deltas already streamed → no re-emit.
+        let c = translate(
+            &ev("session.next.text.ended", json!({"textID":"t1","text":"Hello world"})),
+            &mut st,
+        );
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn text_end_only_build_emits_full_text() {
+        let mut st = TranslateState::default();
+        let c = translate(
+            &ev("session.next.text.ended", json!({"textID":"t9","text":"DONE"})),
+            &mut st,
+        );
+        assert_eq!(c.len(), 1);
+        match &c[0] {
+            SessionEvent::MessageDelta { item_id, text } => {
+                assert_eq!(item_id, "msg-t9");
+                assert_eq!(text, "DONE");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_pipeline_emits_call_then_result() {
+        let mut st = TranslateState::default();
+        translate(
+            &ev(
+                "session.next.tool.input.started",
+                json!({"callID":"call_1","name":"bash"}),
+            ),
+            &mut st,
+        );
+        translate(
+            &ev(
+                "session.next.tool.input.ended",
+                json!({"callID":"call_1","text":"{\"command\":\"echo V2TOOL_OK\"}"}),
+            ),
+            &mut st,
+        );
+        let called = translate(
+            &ev(
+                "session.next.tool.called",
+                json!({"callID":"call_1","tool":"bash","input":{"command":"echo V2TOOL_OK"}}),
+            ),
+            &mut st,
+        );
+        assert_eq!(called.len(), 1);
+        match &called[0] {
+            SessionEvent::ToolCall {
+                tool_use_id,
+                name,
+                input,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "call_1");
+                assert_eq!(name, "bash");
+                assert_eq!(input["command"], "echo V2TOOL_OK");
+            }
+            other => panic!("{other:?}"),
+        }
+        let done = translate(
+            &ev(
+                "session.next.tool.success",
+                json!({"callID":"call_1","structured":{},"content":[{"type":"text","text":"V2TOOL_OK"}]}),
+            ),
+            &mut st,
+        );
+        match &done[0] {
+            SessionEvent::ToolResult {
+                tool_use_id,
+                is_error,
+                content,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "call_1");
+                assert!(!is_error);
+                match &content[0] {
+                    ToolResultContent::Text(t) => assert_eq!(t, "V2TOOL_OK"),
+                    other => panic!("{other:?}"),
+                }
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_input_arrives_finalized_by_ended_event() {
+        // .called must carry the JSON parsed from input.ended's text even when
+        // the .called frame itself has no input field (capture ordering).
+        let mut st = TranslateState::default();
+        translate(
+            &ev("session.next.tool.input.started", json!({"callID":"c","name":"read"})),
+            &mut st,
+        );
+        translate(
+            &ev(
+                "session.next.tool.input.ended",
+                json!({"callID":"c","text":"{\"filePath\":\"a.txt\"}"}),
+            ),
+            &mut st,
+        );
+        let called = translate(
+            &ev("session.next.tool.called", json!({"callID":"c","tool":"read"})),
+            &mut st,
+        );
+        match &called[0] {
+            SessionEvent::ToolCall { input, .. } => assert_eq!(input["filePath"], "a.txt"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn interrupted_tool_surfaces_error() {
+        let mut st = TranslateState::default();
+        let failed = translate(
+            &ev(
+                "session.next.tool.failed",
+                json!({"callID":"call_9","error":{"type":"unknown","message":"Tool execution interrupted"}}),
+            ),
+            &mut st,
+        );
+        match &failed[0] {
+            SessionEvent::ToolResult { is_error, content, .. } => {
+                assert!(is_error);
+                match &content[0] {
+                    ToolResultContent::Text(t) => assert_eq!(t, "Tool execution interrupted"),
+                    other => panic!("{other:?}"),
+                }
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_accumulates_across_steps() {
+        let mut st = TranslateState::default();
+        translate(
+            &ev(
+                "session.next.step.ended",
+                json!({"finish":"tool-calls","cost":0.01,"tokens":{"input":100,"output":20,"reasoning":5,"total":125,"cache":{"read":8,"write":0}}}),
+            ),
+            &mut st,
+        );
+        translate(
+            &ev(
+                "session.next.step.ended",
+                json!({"finish":"stop","cost":0.02,"tokens":{"input":150,"output":30,"reasoning":8,"total":180,"cache":{"read":0,"write":0}}}),
+            ),
+            &mut st,
+        );
+        match st.turn_usage_event() {
+            SessionEvent::UsageDelta {
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                cost_usd,
+                breakdown,
+                ..
+            } => {
+                assert_eq!(input_tokens, 250);
+                assert_eq!(output_tokens, 50);
+                assert_eq!(total_tokens, 300);
+                assert_eq!(breakdown.thought_tokens, 13);
+                assert_eq!(breakdown.cached_read_tokens, 8);
+                assert!((cost_usd.unwrap() - 0.03).abs() < 1e-9);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn reasoning_end_without_deltas_emits_once() {
+        let mut st = TranslateState::default();
+        let out = translate(
+            &ev(
+                "session.next.reasoning.ended",
+                json!({"reasoningID":"r1","text":"thinking…"}),
+            ),
+            &mut st,
+        );
+        assert_eq!(out.len(), 1);
+        translate(
+            &ev("session.next.reasoning.delta", json!({"reasoningID":"r2","delta":"a"})),
+            &mut st,
+        );
+        let out2 = translate(
+            &ev("session.next.reasoning.ended", json!({"reasoningID":"r2","text":"ab"})),
+            &mut st,
+        );
+        assert!(out2.is_empty());
+    }
+
+    #[test]
+    fn question_resolve_maps_request_id() {
+        let mut st = TranslateState::default();
+        let out = translate(
+            &ev(
+                "question.v2.replied",
+                json!({"sessionID":"ses_1","requestID":"que_1","answers":[["red"]]}),
+            ),
+            &mut st,
+        );
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            &out[0],
+            SessionEvent::AskResolved { request_id } if request_id == "que_1"
+        ));
+    }
+
+    #[test]
+    fn permission_resolve_falls_back_to_id_field() {
+        let mut st = TranslateState::default();
+        let out = translate(
+            &ev("permission.v2.replied", json!({"id":"per_42","sessionID":"ses_1"})),
+            &mut st,
+        );
+        assert!(matches!(
+            &out[0],
+            SessionEvent::PermissionResolved { request_id, .. } if request_id == "per_42"
+        ));
+    }
+
+    #[test]
+    fn unknown_events_are_inert() {
+        let mut st = TranslateState::default();
+        assert!(translate(&ev("session.updated", json!({"info":{}})), &mut st).is_empty());
+        assert!(translate(&ev("session.next.mcp.started", json!({"server":"x"})), &mut st).is_empty());
+        assert!(translate(&ev("session.next.text.started", json!({"textID":"t"})), &mut st).is_empty());
+        assert!(
+            translate(
+                &ev("session.next.prompt.admitted", json!({"prompt":{"text":"x"}})),
+                &mut st
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn session_error_maps_to_notice_with_captured_shape() {
+        let mut st = TranslateState::default();
+        let out = translate(
+            &ev(
+                "session.error",
+                json!({"error":{"type":"unknown","data":{"message":"boom"}}}),
+            ),
+            &mut st,
+        );
+        match &out[0] {
+            SessionEvent::Notice { message, .. } => assert_eq!(message, "boom"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancelled_turn_result_carries_user_cancel_outcome() {
+        match turn_result_event(false, true) {
+            SessionEvent::TurnResult { outcome, is_error, .. } => {
+                assert!(!is_error);
+                assert!(matches!(
+                    outcome,
+                    TurnOutcome::Cancelled {
+                        reason: CancelReason::UserCancel
+                    }
+                ));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+}

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1843,6 +1843,145 @@ pub async fn build_antigravity_instance(
     Ok(crate::agent_task::AgentInstance::Session(task))
 }
 
+/// opencode conversation on the SHARED `opencode serve` process
+/// (`AIONUI_OPENCODE_SHARED_SERVER` opt-in). Same shape as
+/// [`build_antigravity_instance`]: the blessed template for a third session
+/// backend that must NOT inherit the claude/codex spawn plumbing (cc-switch
+/// env, codex sandbox/approval derivation, claude thinking flags, the
+/// claude/codex-keyed dev prompt dumps, initial-cost seeding — none of it
+/// applies to a backend that never spawns a per-conversation process).
+///
+/// The connection talks opencode's HTTP/SSE v2 API; the SERVER lifecycle is
+/// owned by the process pool in `opencode_shared`, not by this conversation:
+/// every opencode conversation reuses one `opencode serve` and merely holds a
+/// lease. Killing this session interrupts its turn and releases the lease;
+/// the server goes down only when the last lease does.
+pub async fn build_opencode_instance(
+    inputs: SessionBuildInputs<'_>,
+) -> Result<crate::agent_task::AgentInstance, AgentError> {
+    use aionui_session::{BackendConnection, McpServerSpec, SessionConfig, SessionInit};
+
+    let SessionBuildInputs {
+        conversation_id,
+        user_id,
+        workspace,
+        config,
+        metadata,
+        skill_delivery,
+        session_snapshot,
+        backend_session_id,
+        mcp_server_repo,
+        runtime_env,
+        broadcaster,
+        catalog_writeback,
+        acp_session_repo,
+        // Shared-server mode has no per-conversation spawn to dump the input
+        // of; the dev dump lane is claude/codex-keyed — skip it (agy precedent).
+        prompt_dump_dir: _,
+        // opencode owns permission prompting natively (permission.v2 events);
+        // the claude hook-body channel is meaningless here.
+        permission_hook_body: _,
+    } = inputs;
+
+    let (spec, mode, model) = spec_mode_model(&conversation_id, backend_session_id, config, session_snapshot, metadata);
+
+    // Same neutral MCP init surface as every session backend. opencode loads
+    // MCP from its own config files, so the backend records but cannot yet
+    // push these; they still travel for parity and future wiring (documented
+    // limitation of the shared path).
+    let mut neutral = match mcp_server_repo {
+        Some(repo) => {
+            crate::mcp_resolve::resolve_session_mcp_servers(
+                repo.as_ref(),
+                &user_id,
+                config.mcp_server_ids.as_deref(),
+                &conversation_id,
+                broadcaster.clone(),
+            )
+            .await
+        }
+        None => Vec::new(),
+    };
+    neutral.retain(|server| server.name != TEAM_MCP_SERVER_NAME);
+    neutral.extend(
+        config
+            .session_mcp_servers
+            .iter()
+            .filter(|server| server.name != TEAM_MCP_SERVER_NAME)
+            .cloned(),
+    );
+    let mut mcp_servers: Vec<McpServerSpec> = neutral.iter().map(session_server_to_spec).collect();
+    if let Some(cfg) = config.team_mcp_stdio_config.as_ref() {
+        let mut coordination = vec![team_mcp_server_spec(cfg)];
+        coordination.append(&mut mcp_servers);
+        mcp_servers = coordination;
+    }
+
+    let init = SessionInit {
+        mcp_servers,
+        skills: config.skills.clone(),
+        // The COMPOSED block (assistant rules + skills index): the shared
+        // backend has no CLI-flag channel, so preset_context ahead of the
+        // FIRST prompt is the only injection lane (agy precedent).
+        preset_context: skill_delivery
+            .injected_prefix
+            .clone()
+            .or_else(|| config.preset_context.clone()),
+        // Layer-2 only: no process flags on a shared server.
+        skill_view_skills_dir: None,
+        skill_dirs: skill_delivery.skill_dirs.clone(),
+        session_snapshot: None,
+        resume: matches!(spec, aionui_session::SessionSpec::Resume { .. }),
+    };
+
+    let mut session_config = SessionConfig {
+        cwd: Some(workspace.clone()),
+        model,
+        mode,
+        init,
+        // The SERVER binary: a user-selected path wins; otherwise resolve
+        // `opencode` the same way the ACP path does (bundled path or PATH —
+        // npm installs ship `opencode.cmd` shims on Windows, so a bare name
+        // would not be found by CreateProcess).
+        cli_program: resolve_session_cli_program("opencode", metadata),
+        // No per-conversation flags on a shared process.
+        extra_args: Vec::new(),
+        ..Default::default()
+    };
+    session_config.spawn_env = assemble_spawn_env(&metadata.env, runtime_env);
+
+    let backend = crate::opencode_shared::OpencodeConnection::new()
+        .open_session(spec, session_config)
+        .await
+        .map_err(|e| match e {
+            aionui_session::BackendError::WorkspaceUnavailable(path) => {
+                AgentError::workspace_path_runtime_unavailable(path)
+            }
+            e => AgentError::bad_gateway(format!("open opencode shared session: {e}")),
+        })?;
+
+    if let Some((agent_id, catalog_tx)) = catalog_writeback {
+        spawn_catalog_writeback(agent_id, user_id.clone(), backend.clone(), catalog_tx);
+    }
+
+    // AgentType::Acp, not a new variant: the conversations table rows for
+    // opencode already carry the vendor's original type, and the session seam
+    // dispatches off the backend object — the claude/codex session builders
+    // likewise pass Acp here.
+    let task = SessionAgentTask::new_with_preload(
+        AgentType::Acp,
+        conversation_id,
+        user_id,
+        workspace,
+        backend,
+        acp_session_repo,
+        &metadata.handshake,
+        None,
+        Some(broadcaster),
+    );
+    Ok(crate::agent_task::AgentInstance::Session(task))
+}
+
 /// claude/codex session started through the ACP factory is byte-equivalent to one
 /// started through the clean-slate registry.
 pub async fn build_session_instance(

--- a/crates/aionui-ai-agent/tests/opencode_shared_e2e.rs
+++ b/crates/aionui-ai-agent/tests/opencode_shared_e2e.rs
@@ -1,0 +1,429 @@
+//! Live end-to-end acceptance for the shared `opencode serve` backend
+//! (PR2). These tests drive REAL opencode against the REAL model configured
+//! on the machine, so they are gated behind `AIONUI_OPENCODE_E2E=1` and skip
+//! cleanly (exit 0) otherwise — CI without an opencode install is unaffected.
+//!
+//! Run locally:
+//! ```text
+//! $env:AIONUI_OPENCODE_E2E = "1"
+//! cargo test -p aionui-ai-agent --test opencode_shared_e2e -- --nocapture
+//! ```
+//!
+//! What is proven here (not by the pure unit tests in `opencode_shared`):
+//! 1. TWO conversations share ONE server process (same base_url from the pool
+//!    and a single registry record), with independent durable SSE streams.
+//! 2. A full turn translates: TurnStarted → (deltas) → usage → TurnResult.
+//! 3. Permission flow: the `permission.v2.asked` poll-discovery surfaces a
+//!    `Permission` event; `AnswerPermission(Approved)` unblocks the tool and
+//!    the turn completes.
+//! 4. Resume: a fresh backend instance on the SAME `ses_` id re-binds and
+//!    keeps streaming.
+//! 5. Crash: killing the server yields `Detached`, and the next open respawns
+//!    a healthy server (pool watchdog + registry hygiene).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aionui_ai_agent::opencode_shared::{OpencodeConnection, global_pool};
+use aionui_session::{
+    BackendConnection, CancelTarget, Command, CommandMeta, ContentBlock, PermissionDecision, SessionConfig,
+    SessionEnvelope, SessionEvent, SessionSpec,
+};
+use futures_util::StreamExt;
+
+fn e2e_enabled() -> bool {
+    matches!(
+        std::env::var("AIONUI_OPENCODE_E2E").as_deref(),
+        Ok("1") | Ok("true") | Ok("on") | Ok("yes")
+    )
+}
+
+fn opencode_program() -> Option<PathBuf> {
+    for dir in std::env::split_paths(&std::env::var("PATH").unwrap_or_default()) {
+        for name in ["opencode.exe", "opencode.cmd", "opencode"] {
+            let p = dir.join(name);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+fn base_config(cwd: &Path, program: &Path) -> SessionConfig {
+    SessionConfig {
+        cwd: Some(cwd.to_string_lossy().into_owned()),
+        cli_program: Some(program.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+fn meta() -> CommandMeta {
+    CommandMeta {
+        command_id: 1,
+        cwd: None,
+        extra_args: Vec::new(),
+        client_msg_id: None,
+    }
+}
+
+fn text(s: &str) -> Vec<ContentBlock> {
+    vec![ContentBlock::Text(s.to_string())]
+}
+
+/// Drain `backend`'s event stream until `done` matches or timeout, collecting
+/// everything seen. The stream is a broadcast subscription, so open it BEFORE
+/// dispatching.
+async fn collect_until(
+    rx: &mut futures_util::stream::BoxStream<'static, SessionEnvelope>,
+    timeout: Duration,
+    done: impl Fn(&SessionEvent) -> bool,
+    seen: &std::sync::Arc<std::sync::Mutex<Vec<SessionEvent>>>,
+) -> bool {
+    let fut = async {
+        while let Some(env) = rx.next().await {
+            let hit = done(&env.event);
+            seen.lock().unwrap().push(env.event);
+            if hit {
+                return true;
+            }
+        }
+        false
+    };
+    tokio::time::timeout(timeout, fut).await.unwrap_or(false)
+}
+
+fn snapshot(seen: &std::sync::Arc<std::sync::Mutex<Vec<SessionEvent>>>) -> Vec<SessionEvent> {
+    seen.lock().unwrap().clone()
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!(
+        "aionui-opencode-e2e-{}-{:x}",
+        tag,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+/// #1 + #2 + #4: one server, two conversations, full translated turns, then
+/// one of them RESUMES from its `ses_` anchor.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shared_server_hosts_two_conversations() {
+    if !e2e_enabled() {
+        eprintln!("SKIP: set AIONUI_OPENCODE_E2E=1 to run live opencode shared-server E2E");
+        return;
+    }
+    let program = opencode_program().expect("opencode not on PATH");
+    let conn = OpencodeConnection::new();
+    let dir_a = scratch("alpha");
+    let dir_b = scratch("bravo");
+
+    // ---- conversation A: first open spawns the server ----------------------
+    let a = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: "e2e-a".into(),
+            },
+            base_config(&dir_a, &program),
+        )
+        .await
+        .expect("open A");
+    let mut rx_a = a.events();
+    let seen_a = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    // ---- conversation B: MUST reuse the same server ------------------------
+    let b = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: "e2e-b".into(),
+            },
+            base_config(&dir_b, &program),
+        )
+        .await
+        .expect("open B");
+    let seen_b = Arc::new(std::sync::Mutex::new(Vec::<SessionEvent>::new()));
+
+    let info = global_pool()
+        .peek(&program)
+        .await
+        .expect("pool must host the shared server");
+    assert!(info.base_url.starts_with("http://127.0.0.1:"), "{info:?}");
+    // One registry record, pointing at exactly this port = one process.
+    let reg_dir = std::env::temp_dir().join("aionui-opencode-shared");
+    let records: Vec<std::fs::DirEntry> = std::fs::read_dir(&reg_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .collect();
+    assert_eq!(records.len(), 1, "exactly one registry record expected");
+
+    // ---- BackendBound carries the ses_ ids, and they DIFFER ---------------
+    let bound_a = collect_until(
+        &mut rx_a,
+        Duration::from_secs(20),
+        |e| matches!(e, SessionEvent::BackendBound { .. }),
+        &seen_a,
+    )
+    .await;
+    let ses_a = snapshot(&seen_a)
+        .into_iter()
+        .find_map(|e| match e {
+            SessionEvent::BackendBound { backend_session_id } => backend_session_id,
+            _ => None,
+        })
+        .expect("A bound to a ses_ id");
+    assert!(ses_a.starts_with("ses_"), "A got {ses_a}");
+    assert!(bound_a);
+
+    // (B's BackendBound was emitted at open time; B liveness is proven via
+    // its own first turn below on a freshly-subscribed receiver instead.)
+
+    // ---- A full turn on A --------------------------------------------------
+    a.dispatch(Command::Send {
+        content: text("Reply with exactly this word and nothing else: ALPHA-OK"),
+        metadata: meta(),
+    })
+    .await
+    .expect("send A admitted");
+    let completed_a = collect_until(
+        &mut rx_a,
+        Duration::from_secs(240),
+        |e| matches!(e, SessionEvent::TurnResult { .. }),
+        &seen_a,
+    )
+    .await;
+    assert!(completed_a, "A never terminated the turn");
+    let evs_a = snapshot(&seen_a);
+    assert!(
+        evs_a.iter().any(|e| matches!(e, SessionEvent::TurnStarted { .. })),
+        "A missing TurnStarted"
+    );
+    assert!(
+        evs_a.iter().any(|e| matches!(e, SessionEvent::MessageDelta { .. }))
+            || evs_a
+                .iter()
+                .any(|e| matches!(e, SessionEvent::TurnResult { is_error: false, .. })),
+        "A produced neither deltas nor a clean result: {evs_a:?}"
+    );
+
+    // ---- B's turn proves the SECOND stream is independent ------------------
+    // (A goes busy-then-idle on one server while B runs its own turn.)
+    // events() hands out a fresh broadcast receiver per call.
+    let mut rx_b2 = b.events();
+    b.dispatch(Command::Send {
+        content: text("Reply with exactly this word and nothing else: BRAVO-OK"),
+        metadata: meta(),
+    })
+    .await
+    .expect("send B admitted");
+    let seen_b_collector = seen_b.clone();
+    let done_b = tokio::time::timeout(Duration::from_secs(240), async {
+        while let Some(env) = rx_b2.next().await {
+            let hit = matches!(env.event, SessionEvent::TurnResult { .. });
+            seen_b_collector.lock().unwrap().push(env.event);
+            if hit {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false);
+    assert!(done_b, "B never terminated its turn on the shared server");
+
+    // ---- resume A on a fresh backend instance ------------------------------
+    drop(a);
+    let a2 = conn
+        .open_session(
+            SessionSpec::Resume {
+                session_id: "e2e-a2".into(),
+                backend_session_id: Some(ses_a.clone()),
+            },
+            base_config(&dir_a, &program),
+        )
+        .await
+        .expect("resume A");
+    let mut rx_a2 = a2.events();
+    let seen_a2 = Arc::new(std::sync::Mutex::new(Vec::new()));
+    a2.dispatch(Command::Send {
+        content: text("Reply with exactly this word and nothing else: RESUME-OK"),
+        metadata: meta(),
+    })
+    .await
+    .expect("resumed A send admitted");
+    let done_a2 = collect_until(
+        &mut rx_a2,
+        Duration::from_secs(240),
+        |e| matches!(e, SessionEvent::TurnResult { .. }),
+        &seen_a2,
+    )
+    .await;
+    assert!(done_a2, "resumed session never terminated its turn");
+    // The resumed turn must carry a higher turn generation than nothing —
+    // and the pool still hosts exactly ONE server (nothing respawned).
+    let info2 = global_pool().peek(&program).await.expect("still hosted");
+    assert_eq!(info.base_url, info2.base_url, "resume must NOT spawn a second server");
+}
+
+/// #3: bash permission approval round-trip against a workspace whose
+/// `.opencode/opencode.json` asks (`{"permission":{"bash":"ask"}}`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn permission_approval_unblocks_the_turn() {
+    if !e2e_enabled() {
+        eprintln!("SKIP: set AIONUI_OPENCODE_E2E=1 to run live opencode shared-server E2E");
+        return;
+    }
+    let program = opencode_program().expect("opencode not on PATH");
+    // Dedicated dir so the ask-rule is the only permission config in scope.
+    let dir = scratch("perm");
+    std::fs::create_dir_all(dir.join(".opencode")).unwrap();
+    std::fs::write(
+        dir.join(".opencode").join("opencode.json"),
+        r#"{"permission":{"bash":"ask"}}"#,
+    )
+    .unwrap();
+
+    let conn = OpencodeConnection::new();
+    let be = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: "e2e-perm".into(),
+            },
+            base_config(&dir, &program),
+        )
+        .await
+        .expect("open perm session");
+    let mut rx = be.events();
+    let mut saw_permission = false;
+    let mut answered = false;
+    let mut completed = false;
+
+    be.dispatch(Command::Send {
+        content: text(
+            "Use the bash tool to run exactly: echo PERMISSION-E2E \
+             Then reply with the tool output.",
+        ),
+        metadata: meta(),
+    })
+    .await
+    .expect("admitted");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+    while tokio::time::Instant::now() < deadline {
+        let Ok(Some(env)) = tokio::time::timeout(Duration::from_secs(5), rx.next()).await else {
+            continue; // idle — the pending-poll surfaces permissions on its own pace
+        };
+        match &env.event {
+            SessionEvent::Permission { request_id, .. } => {
+                saw_permission = true;
+                if !answered {
+                    be.dispatch(Command::AnswerPermission {
+                        request_id: request_id.clone(),
+                        decision: PermissionDecision::Approved,
+                        selected: None,
+                        answers: Vec::new(),
+                    })
+                    .await
+                    .expect("approve permission admitted");
+                    answered = true;
+                }
+            }
+            SessionEvent::TurnResult { is_error, .. } => {
+                completed = true;
+                assert!(!is_error, "permission turn errored: {:?}", env.event);
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_permission, "no Permission event from poll-discovery");
+    assert!(answered, "never answered");
+    assert!(completed, "turn never completed after approval");
+}
+
+/// #5: killing the shared server surfaces Detached, and the pool respawns a
+/// healthy server for the next open.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn server_crash_detaches_then_resumes_on_next_open() {
+    if !e2e_enabled() {
+        eprintln!("SKIP: set AIONUI_OPENCODE_E2E=1 to run live opencode shared-server E2E");
+        return;
+    }
+    let program = opencode_program().expect("opencode not on PATH");
+    let dir = scratch("crash");
+    let conn = OpencodeConnection::new();
+    let be = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: "e2e-crash".into(),
+            },
+            base_config(&dir, &program),
+        )
+        .await
+        .expect("open crash session");
+    let mut rx = be.events();
+
+    let info = global_pool().peek(&program).await.expect("hosted");
+    let pid = info.pid.expect("own spawn records pid");
+
+    // Hard-kill the server (we own it: the pool spawned this pid).
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+
+    let detached = tokio::time::timeout(Duration::from_secs(30), async {
+        while let Some(env) = rx.next().await {
+            if matches!(env.event, SessionEvent::Detached { .. }) {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false);
+    assert!(detached, "server death never surfaced as Detached");
+    drop(be);
+
+    // Next open must respawn (stale registry record health-fails → fresh spawn).
+    let be2 = conn
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: "e2e-crash-2".into(),
+            },
+            base_config(&dir, &program),
+        )
+        .await
+        .expect("respawn after crash");
+    let info2 = global_pool().peek(&program).await.expect("respawned");
+    assert_ne!(info.base_url, info2.base_url, "respawn uses a fresh port");
+    let mut rx2 = be2.events();
+    be2.dispatch(Command::Send {
+        content: text("Reply with exactly: RESPAWN-OK"),
+        metadata: meta(),
+    })
+    .await
+    .expect("post-crash send");
+    let done = tokio::time::timeout(Duration::from_secs(240), async {
+        while let Some(env) = rx2.next().await {
+            if matches!(env.event, SessionEvent::TurnResult { .. }) {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false);
+    assert!(done, "post-crash turn never completed");
+    // Cancel on an idle session is a benign no-op, not an error.
+    let _ = be2
+        .dispatch(Command::Cancel {
+            target: CancelTarget::Turn,
+        })
+        .await;
+}


### PR DESCRIPTION
## Problem
Every opencode conversation spawns a dedicated `opencode acp` child — N conversations means N full bun runtimes (memory, startup, port pressure; the backdrop of the USER_AGENT_STARTUP_FAILED reports).

## Change
Opt-in (`AIONUI_OPENCODE_SHARED_SERVER=on`; default OFF leaves the ACP path byte-identical) single-process mode: all opencode conversations attach via the existing `AgentInstance::Session(Arc<dyn SessionBackend>)` seam to ONE pooled `opencode serve` over its HTTP/SSE v2 API.

- `opencode_shared` module: process pool (registry-backed adopt-or-spawn, watchdog, lease-counted teardown that only ever kills its own pid), v2 client, durable per-session SSE with cursor reconnect, event translator, permission/question poll-discovery, active-map turn closure.
- Factory: toggle-gated branch ahead of the ACP table (route table + its tests untouched); `build_opencode_instance` follows the antigravity third-backend template.
- Documented shared-mode limits: fork refused, MCP stays config-file based, no per-conversation spawn env (`AIONUI_CONVERSATION_ID` stripped).

## Testing
- `cargo test -p aionui-ai-agent`: 984 pass (incl. 16 new unit tests for the translator/client/SSE parser; the 5 `terminal::tests` failures are pre-existing Windows env issues unrelated to this change).
- Workspace `cargo check` + `clippy --all-targets` + `fmt --check` clean.
- Live E2E (`tests/opencode_shared_e2e.rs`, gated behind `AIONUI_OPENCODE_E2E=1`): one server process hosts >=2 conversations (single registry record, independent streams, full turn translation), resume across backend instances from the `ses_` anchor, bash-permission approval round-trip via poll-discovered `Permission` events, and server kill -> `Detached` -> automatic respawn. All green on Windows against opencode 1.18.30.