### PR TITLE
chore(acp): bump codebuddy, dimcode, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -9,7 +9,7 @@
     "codebuddy": {
       "registry_json_id": "codebuddy-code",
       "package": "@tencent-ai/codebuddy-code",
-      "version": "2.147.0"
+      "version": "2.148.0"
     },
     "deepagents": {
       "registry_json_id": "deepagents",
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.32"
+      "version": "0.5.1"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.24"
+      "version": "1.0.27"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.5.16"
+      "version": "7.6.0"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -120,7 +120,7 @@ mod tests {
             [
                 "-y",
                 "--package",
-                "@tencent-ai/codebuddy-code@2.147.0",
+                "@tencent-ai/codebuddy-code@2.148.0",
                 "codebuddy",
                 "--acp"
             ]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #980, each backed by a fresh serial ACP probe of the exact pinned version. The diff is the lock file plus the one lock-derived test assertion that embeds codebuddy's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| codebuddy | `@tencent-ai/codebuddy-code` | 2.147.0 → **2.148.0** | ok (protocolVersion 1) | auth required (`-32000`, `data.category: auth`) |
| dimcode | `dimcode` | 0.3.32 → **0.5.1** | ok (agentInfo version 0.5.1) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 1.0.24 → **1.0.27** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.5.16 → **7.6.0** | ok (agentInfo Kilo 7.6.0) | **succeeded** unauthenticated |

All four meet the release-lock criterion: `initialize` succeeds, and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

**Two of these cross a minor series, so their entrypoints were exercised rather than assumed.** dimcode jumps from 0.3.32 straight to **0.5.1**, skipping the entire 0.4.x line — the Registry still declares the bare `acp` subcommand, and that exact invocation completed `initialize` with `agentInfo` self-reporting 0.5.1 before returning its usual credentials error. kilo moves 7.5.16 → **7.6.0** and its `acp` entrypoint still opens a session advertising model, thought_level, and mode. Neither session catalog is persisted; skill step 11 leaves those columns to the runtime.

dimcode continues to self-report `agentInfo.title` as "DimAgent" against a public listing of "DimCode" — a standing vendor quirk across this whole version jump, not an AionCore defect.

**Snapshot structural diff** (against `v2026.09.09-cfa1ca8`): the id set holds at 40 and every change is version churn — no distribution type added or removed, and `args`/`env` are byte-identical for every npx entry, including for the two minor-series jumps above. Non-lock movement is report-only: claude-agent-acp 0.76.0, codex-acp 1.11.0, factory-droid 0.216.0, qwen-code 0.23.3, plus new binary artifacts for devin, kilo's binary channel, and kimchi.

**Derived assertion updated:** `registry_npx_lock.rs` pins codebuddy's exact version inside a `--package`-form argument list, so it moves with the lock — `2.147.0` → `2.148.0`. All four outgoing versions were scanned across `crates/**/*.rs` with fixed-string matching before staging; codebuddy's is the only real assertion and the other three have no hits. `npx_cache_repair.rs` keeps its own version literals: those are cache-path hash fixtures, not lock assertions.

The other 7 Registry-pinned packages (autohand, deepagents, dirac, glm-acp-agent, nova, pi, sigit) match the snapshot exactly. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

**Standing watches (unchanged, no action in this PR):**
- `kimchi` (listed 2026-09-09) stays deferred — binary-only, so it cannot enter the npx release lock; its binary artifact moved again this window. Integrating it needs a binary install/update path plus a seed migration, which is a human-reviewed change.
- sigit's npm scope rename (`@smbcloud/sigit` → `@getsigit/sigit`) is still only a vendor stderr notice; the Registry declares the old scope, so the pin is untouched.

## Registry snapshot

- Audit pinned to release tag [`v2026.09.10-797d203`](https://cdn.agentclientprotocol.com/registry/v1/v2026.09.10-797d203/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- 40 ids in the raw snapshot: no newly listed and no delisted agents versus the previous run. (`antigravity-acp` and `kimchi` remain listed and deferred as binary-only; `fast-agent` and `minion-code` remain listed but uvx-only and therefore out of scope.)

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock version bumps plus one test assertion; existing startup/session error paths already identify a failing agent by backend.
