### PR TITLE
chore(cli-version): verify agy against 1.2.0

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -38,7 +38,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.236";
 pub const VERIFIED_CODEX_VERSION: &str = "0.151.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.28";
+pub const VERIFIED_AGY_VERSION: &str = "1.2.0";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.
@@ -475,13 +475,15 @@ mod tests {
         // The literal the other two CLIs already pin, which agy was missing: a
         // user on exactly the verified release is told nothing, and a bump that
         // lands without re-verifying against that exact binary breaks here.
-        assert_eq!(classify("1.1.28", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("agy", "1.1.28", VERIFIED_AGY_VERSION).is_none());
+        assert_eq!(classify("1.2.0", VERIFIED_AGY_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("agy", "1.2.0", VERIFIED_AGY_VERSION).is_none());
 
         // agy prints a bare version, so the older/newer paths are worth pinning
         // on that exact shape rather than only on a decorated one.
-        assert_eq!(classify("1.1.27", VERIFIED_AGY_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("1.1.29", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
+        // 1.1.29 is OLDER than 1.2.0: the minor component decides, and a
+        // lexical compare would get this backwards ("1.1.29" > "1.2.0").
+        assert_eq!(classify("1.1.29", VERIFIED_AGY_VERSION), VersionVerdict::Older);
+        assert_eq!(classify("1.2.1", VERIFIED_AGY_VERSION), VersionVerdict::Newer);
     }
 
     /// Both drift directions are `Info` — the tier the frontend draws as a quiet


### PR DESCRIPTION
Moves `VERIFIED_AGY_VERSION` from 1.1.28 to **1.2.0** — the first non-patch agy bump in this series.

| Gate | Result |
| --- | --- |
| A — contract | DEGRADED — agy publishes no protocol schema; gate B carries the weight |
| B — live e2e | **PASS 7/7**, 141.76s |
| C — release notes | **CLEAR** |

## The minor version moves nothing we drive

Checked first, because that is what a minor bump warrants. `--help` and `models --help` are **byte-identical** 1.1.28 → 1.2.0, diffed against the captures stored with the previous record rather than by re-running the old binary (which would have self-updated it away). All nine flags `build_argv` emits are present.

Gate B ran against a manifest download whose sha512 was checked before it executed; the log reports only `version=1.2.0`, and the binary was byte-identical before and after (`mtime=06:30:29 size=178935744`). The machine's own agy stayed on 1.1.18.

## Everything on our surface is a fix

- **Content-safety-filtered prompts** no longer fail with a spurious *"no candidate found"*, **end silently with an empty turn**, or retry the rejected input — the CLI now surfaces a content-filter stop reason. "Ending silently with an empty turn" is the exact failure shape these gates keep turning up, so this removes a real class of it.
- **Older conversations no longer fail to resume** with `unknown step type`. We resume through `--conversation`, so this is directly our path.
- **Third-party MCP tools** whose input schemas omit `additionalProperties` no longer fail validation. Gate B drives an MCP tool call and it passed.
- The per-message filesystem customization discovery walk is gone — latency on our path.

**The new stop reason is the only addition to the wire, and it cannot break us:** `wire.rs` is tolerant by construction (its own header says so), the state enum carries `#[serde(other)] Unknown`, and we do not consume a stop-reason field at all — grepped, no `stop_reason` / `finish_reason` anywhere under `backend/antigravity/`.

## Not our surface

`remote-control start/status/stop` as an OS-registered service, half-page scrolling and `navigation.half_page_*` keybindings, `scratch/` files churning the artifact panel, plugin-bundled MCP initialisation, and the `ERROR: logging before google.Init` prefix in `cli.log`.

## A grep trap worth knowing for this page

The web changelog interleaves **Antigravity Hub** releases (2.x, and 1.2x.y such as `1.21.6`, `1.22.2`) with CLI releases, so a bare `1\.[0-9]+\.[0-9]+` matches Hub entries and produced a nonsense "latest CLI" list on the first attempt. Anchor on the CLI-section link instead:

```bash
grep -oE 'View release [0-9]+\.[0-9]+\.[0-9]+' <page> | sed 's/View release //' | sort -u -V
```

Both sources carry 1.2.0 and agree.

## Tests

The pinned older/newer pair moves to `1.1.29` / `1.2.1` rather than `1.1.27` / `1.1.29`. That is deliberate: **1.1.29 vs 1.2.0 is exactly where a lexical compare gets the answer backwards**, so the assertion now guards the component-wise comparison at the boundary that just became reachable. `cargo test -p aionui-session --lib cli_version`: 14/14. Clippy clean, fmt clean.

Record: `~/aion/protocols/samples/antigravity-cli/1.2.0/`

Constants and record only — no source change.
